### PR TITLE
SummaryApi 리팩토링 및 긴글요약 UI 변경

### DIFF
--- a/PJ3T3_Postie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PJ3T3_Postie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "80b28216e3b9698278981fea0e0b3236fc9f0451523b03f4389c82f65dd436e6",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
-        "version" : "1.2022062300.0"
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
-        "version" : "10.18.1"
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "b880ec8ec927a838c51c12862c6222c30d7097d7",
-        "version" : "10.20.0"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ceec9f28dea12b7cf3dabf18b5ed7621c88fd4aa",
-        "version" : "10.20.0"
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
       }
     },
     {
@@ -77,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
-        "version" : "1.49.1"
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
       }
     },
     {
@@ -163,5 +164,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -178,20 +178,17 @@ struct AddLetterView: View {
                 Task {
                     await addLetterViewModel.getSummary()
                 }
-//                if !addLetterViewModel.showingSummaryErrorAlert {
-//                    showPopup.toggle()
-//                }
                 focusField = .summary
             }
         }
         .sheet(isPresented: $addLetterViewModel.showingPopup) {
                     PopupView
                 }
-//        .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
-//            if shouldDismiss {
-//                dismiss()
-//            }
-//        }
+        .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
+            if shouldDismiss {
+                dismiss()
+            }
+        }
     }
 }
 
@@ -356,23 +353,35 @@ extension AddLetterView {
     
     @ViewBuilder
     private var PopupView: some View {
-        NavigationView {
-            VStack {
-                HStack {
-                    Button("취소") {
-                        addLetterViewModel.showingPopup = false
-                    }
-                    .padding()
+        VStack {
+            Text("요약 선택")
+                .font(.headline)
+                .padding()
+
+            // summaryList에서 하나를 선택할 수 있는 기능
+            List(addLetterViewModel.summaryList, id: \.self) { summary in
+                Button(action: {
+                    addLetterViewModel.selectedSummary = summary
+                }) {
                     
-                    Spacer()
-                    
-                    Button("확인") {
-                        addLetterViewModel.showingPopup = false
-                    }
+                Text(summary)
                     .padding()
+                    .foregroundColor(addLetterViewModel.selectedSummary == summary ? .blue : .black)
                 }
             }
-            .navigationTitle("항목 선택")
+
+            Button("확인") {
+                addLetterViewModel.summary = addLetterViewModel.selectedSummary
+                addLetterViewModel.showSummaryTextField()
+                addLetterViewModel.closePopup()
+            }
+            .padding()
+            .disabled(addLetterViewModel.selectedSummary.isEmpty) // 선택해야 확인 버튼 활성화
+
+            Button("취소") {
+                addLetterViewModel.closePopup()
+            }
+            .padding()
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -182,8 +182,10 @@ struct AddLetterView: View {
             }
         }
         .sheet(isPresented: $addLetterViewModel.showingPopup) {
-                    PopupView
-                }
+            PopupView
+                .presentationDetents([.fraction(0.7)])
+                .interactiveDismissDisabled(true)
+        }
         .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
@@ -353,35 +355,55 @@ extension AddLetterView {
     
     @ViewBuilder
     private var PopupView: some View {
-        VStack {
-            Text("요약 선택")
-                .font(.headline)
-                .padding()
-
-            // summaryList에서 하나를 선택할 수 있는 기능
-            List(addLetterViewModel.summaryList, id: \.self) { summary in
-                Button(action: {
-                    addLetterViewModel.selectedSummary = summary
-                }) {
+        ZStack {
+            postieColors.backGroundColor
+                .ignoresSafeArea()
+            
+            VStack {
+                Text("요약 선택")
+                    .font(.title)
+                    .bold()
+                    .foregroundStyle(postieColors.tintColor)
+                    .padding(.top)
+                
+                // summaryList에서 하나를 선택할 수 있는 기능
+                List(addLetterViewModel.summaryList, id: \.self) { summary in
+                    Button(action: {
+                        addLetterViewModel.selectedSummary = summary
+                    }) {
+                        Text(summary)
+                            .padding()
+                            .foregroundColor(addLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                            .fontWeight(addLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                    }
+                    .listRowBackground(postieColors.receivedLetterColor)
+                }
+                .scrollContentBackground(.hidden)
+                
+                HStack {
+                    Spacer()
                     
-                Text(summary)
+                    Button("취소") {
+                        addLetterViewModel.closePopup()
+                    }
+                    .foregroundStyle(postieColors.tabBarTintColor)
                     .padding()
-                    .foregroundColor(addLetterViewModel.selectedSummary == summary ? .blue : .black)
+                    
+                    Spacer()
+                    
+                    Button("확인") {
+                        addLetterViewModel.summary = addLetterViewModel.selectedSummary
+                        addLetterViewModel.showSummaryTextField()
+                        addLetterViewModel.closePopup()
+                    }
+                    .foregroundStyle(addLetterViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
+                    .fontWeight(addLetterViewModel.selectedSummary.isEmpty ? .regular : .bold)
+                    .padding()
+                    .disabled(addLetterViewModel.selectedSummary.isEmpty) // 선택해야 확인 버튼 활성화
+                    
+                    Spacer()
                 }
             }
-
-            Button("확인") {
-                addLetterViewModel.summary = addLetterViewModel.selectedSummary
-                addLetterViewModel.showSummaryTextField()
-                addLetterViewModel.closePopup()
-            }
-            .padding()
-            .disabled(addLetterViewModel.selectedSummary.isEmpty) // 선택해야 확인 버튼 활성화
-
-            Button("취소") {
-                addLetterViewModel.closePopup()
-            }
-            .padding()
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -181,8 +181,8 @@ struct AddLetterView: View {
                 focusField = .summary
             }
         }
-        .sheet(isPresented: $addLetterViewModel.showingPopup) {
-            PopupView
+        .sheet(isPresented: $addLetterViewModel.showingSelectSummaryView) {
+            SelectSummaryView
                 .presentationDetents([.fraction(0.7)])
                 .interactiveDismissDisabled(true)
         }
@@ -354,7 +354,7 @@ extension AddLetterView {
     }
     
     @ViewBuilder
-    private var PopupView: some View {
+    private var SelectSummaryView: some View {
         ZStack {
             postieColors.backGroundColor
                 .ignoresSafeArea()
@@ -384,7 +384,7 @@ extension AddLetterView {
                     Spacer()
                     
                     Button("취소") {
-                        addLetterViewModel.closePopup()
+                        addLetterViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(postieColors.tabBarTintColor)
                     .padding()
@@ -394,7 +394,7 @@ extension AddLetterView {
                     Button("확인") {
                         addLetterViewModel.summary = addLetterViewModel.selectedSummary
                         addLetterViewModel.showSummaryTextField()
-                        addLetterViewModel.closePopup()
+                        addLetterViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(addLetterViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
                     .fontWeight(addLetterViewModel.selectedSummary.isEmpty ? .regular : .bold)

--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -178,14 +178,20 @@ struct AddLetterView: View {
                 Task {
                     await addLetterViewModel.getSummary()
                 }
+//                if !addLetterViewModel.showingSummaryErrorAlert {
+//                    showPopup.toggle()
+//                }
                 focusField = .summary
             }
         }
-        .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
-            if shouldDismiss {
-                dismiss()
-            }
-        }
+        .sheet(isPresented: $addLetterViewModel.showingPopup) {
+                    PopupView
+                }
+//        .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
+//            if shouldDismiss {
+//                dismiss()
+//            }
+//        }
     }
 }
 
@@ -345,6 +351,28 @@ extension AddLetterView {
                         addLetterViewModel.showSummaryConfirmationDialog()
                     }
             }
+        }
+    }
+    
+    @ViewBuilder
+    private var PopupView: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    Button("취소") {
+                        addLetterViewModel.showingPopup = false
+                    }
+                    .padding()
+                    
+                    Spacer()
+                    
+                    Button("확인") {
+                        addLetterViewModel.showingPopup = false
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("항목 선택")
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -183,7 +183,7 @@ struct AddLetterView: View {
         }
         .sheet(isPresented: $addLetterViewModel.showingSelectSummaryView) {
             SelectSummaryView
-                .presentationDetents([.fraction(0.7)])
+                .presentationDetents([.medium])
                 .interactiveDismissDisabled(true)
         }
         .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
@@ -359,26 +359,39 @@ extension AddLetterView {
             postieColors.backGroundColor
                 .ignoresSafeArea()
             
-            VStack {
+            VStack(spacing : 0) {
                 Text("요약 선택")
                     .font(.title)
                     .bold()
                     .foregroundStyle(postieColors.tintColor)
-                    .padding(.top)
+                    .padding()
+                    .padding(.top, 5)
                 
-                // summaryList에서 하나를 선택할 수 있는 기능
-                List(addLetterViewModel.summaryList, id: \.self) { summary in
-                    Button(action: {
-                        addLetterViewModel.selectedSummary = summary
-                    }) {
-                        Text(summary)
-                            .padding()
-                            .foregroundColor(addLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
-                            .fontWeight(addLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                ScrollView (showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        // summaryList에서 하나를 선택할 수 있는 기능
+                        ForEach(addLetterViewModel.summaryList.indices, id: \.self) { index in
+                            let summary = addLetterViewModel.summaryList[index]
+
+                            Button(action: {
+                                addLetterViewModel.selectedSummary = summary
+                            }) {
+                                Text(summary)
+                                    .padding()
+                                    .foregroundColor(addLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                                    .fontWeight(addLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                                    .frame(maxWidth: .infinity)
+                                    .background(postieColors.receivedLetterColor)
+                                    .cornerRadius(10)
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 5)
+                        }
                     }
-                    .listRowBackground(postieColors.receivedLetterColor)
                 }
                 .scrollContentBackground(.hidden)
+                
+                Spacer()
                 
                 HStack {
                     Spacer()

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -153,8 +153,8 @@ struct EditLetterView: View {
                 focusField = .summary
             }
         }
-        .sheet(isPresented: $editLetterViewModel.showingPopup) {
-            PopupView
+        .sheet(isPresented: $editLetterViewModel.showingSelectSummaryView) {
+            SelectSummaryView
                 .presentationDetents([.fraction(0.7)])
                 .interactiveDismissDisabled(true)
         }
@@ -356,7 +356,7 @@ extension EditLetterView {
     }
     
     @ViewBuilder
-    private var PopupView: some View {
+    private var SelectSummaryView: some View {
         ZStack {
             postieColors.backGroundColor
                 .ignoresSafeArea()
@@ -386,7 +386,7 @@ extension EditLetterView {
                     Spacer()
                     
                     Button("취소") {
-                        editLetterViewModel.closePopup()
+                        editLetterViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(postieColors.tabBarTintColor)
                     .padding()
@@ -396,7 +396,7 @@ extension EditLetterView {
                     Button("확인") {
                         editLetterViewModel.summary = editLetterViewModel.selectedSummary
                         editLetterViewModel.showSummaryTextField()
-                        editLetterViewModel.closePopup()
+                        editLetterViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(editLetterViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
                     .fontWeight(editLetterViewModel.selectedSummary.isEmpty ? .regular : .bold)

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -153,6 +153,11 @@ struct EditLetterView: View {
                 focusField = .summary
             }
         }
+        .sheet(isPresented: $editLetterViewModel.showingPopup) {
+            PopupView
+                .presentationDetents([.fraction(0.7)])
+                .interactiveDismissDisabled(true)
+        }
         .customOnChange(editLetterViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
@@ -346,6 +351,60 @@ extension EditLetterView {
                     .onTapGesture {
                         editLetterViewModel.showSummaryConfirmationDialog()
                     }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var PopupView: some View {
+        ZStack {
+            postieColors.backGroundColor
+                .ignoresSafeArea()
+            
+            VStack {
+                Text("요약 선택")
+                    .font(.title)
+                    .bold()
+                    .foregroundStyle(postieColors.tintColor)
+                    .padding(.top)
+                
+                // summaryList에서 하나를 선택할 수 있는 기능
+                List(editLetterViewModel.summaryList, id: \.self) { summary in
+                    Button(action: {
+                        editLetterViewModel.selectedSummary = summary
+                    }) {
+                        Text(summary)
+                            .padding()
+                            .foregroundColor(editLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                            .fontWeight(editLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                    }
+                    .listRowBackground(postieColors.receivedLetterColor)
+                }
+                .scrollContentBackground(.hidden)
+                
+                HStack {
+                    Spacer()
+                    
+                    Button("취소") {
+                        editLetterViewModel.closePopup()
+                    }
+                    .foregroundStyle(postieColors.tabBarTintColor)
+                    .padding()
+                    
+                    Spacer()
+                    
+                    Button("확인") {
+                        editLetterViewModel.summary = editLetterViewModel.selectedSummary
+                        editLetterViewModel.showSummaryTextField()
+                        editLetterViewModel.closePopup()
+                    }
+                    .foregroundStyle(editLetterViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
+                    .fontWeight(editLetterViewModel.selectedSummary.isEmpty ? .regular : .bold)
+                    .padding()
+                    .disabled(editLetterViewModel.selectedSummary.isEmpty) // 선택해야 확인 버튼 활성화
+                    
+                    Spacer()
+                }
             }
         }
     }

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -155,7 +155,7 @@ struct EditLetterView: View {
         }
         .sheet(isPresented: $editLetterViewModel.showingSelectSummaryView) {
             SelectSummaryView
-                .presentationDetents([.fraction(0.7)])
+                .presentationDetents([.medium])
                 .interactiveDismissDisabled(true)
         }
         .customOnChange(editLetterViewModel.shouldDismiss) { shouldDismiss in
@@ -361,26 +361,39 @@ extension EditLetterView {
             postieColors.backGroundColor
                 .ignoresSafeArea()
             
-            VStack {
+            VStack(spacing : 0) {
                 Text("요약 선택")
                     .font(.title)
                     .bold()
                     .foregroundStyle(postieColors.tintColor)
-                    .padding(.top)
+                    .padding()
+                    .padding(.top, 5)
                 
-                // summaryList에서 하나를 선택할 수 있는 기능
-                List(editLetterViewModel.summaryList, id: \.self) { summary in
-                    Button(action: {
-                        editLetterViewModel.selectedSummary = summary
-                    }) {
-                        Text(summary)
-                            .padding()
-                            .foregroundColor(editLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
-                            .fontWeight(editLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                ScrollView (showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        // summaryList에서 하나를 선택할 수 있는 기능
+                        ForEach(editLetterViewModel.summaryList.indices, id: \.self) { index in
+                            let summary = editLetterViewModel.summaryList[index]
+
+                            Button(action: {
+                                editLetterViewModel.selectedSummary = summary
+                            }) {
+                                Text(summary)
+                                    .padding()
+                                    .foregroundColor(editLetterViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                                    .fontWeight(editLetterViewModel.selectedSummary == summary ? .bold : .regular)
+                                    .frame(maxWidth: .infinity)
+                                    .background(postieColors.receivedLetterColor)
+                                    .cornerRadius(10)
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 5)
+                        }
                     }
-                    .listRowBackground(postieColors.receivedLetterColor)
                 }
                 .scrollContentBackground(.hidden)
+                
+                Spacer()
                 
                 HStack {
                     Spacer()

--- a/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
@@ -181,6 +181,11 @@ struct SlowPostBoxView: View {
                 focusField = .summary
             }
         }
+        .sheet(isPresented: $slowPostBoxViewModel.showingPopup) {
+            PopupView
+                .presentationDetents([.fraction(0.7)])
+                .interactiveDismissDisabled(true)
+        }
         .customOnChange(slowPostBoxViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
@@ -346,6 +351,60 @@ extension SlowPostBoxView {
                     .onTapGesture {
                         slowPostBoxViewModel.showSummaryConfirmationDialog()
                     }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var PopupView: some View {
+        ZStack {
+            postieColors.backGroundColor
+                .ignoresSafeArea()
+            
+            VStack {
+                Text("요약 선택")
+                    .font(.title)
+                    .bold()
+                    .foregroundStyle(postieColors.tintColor)
+                    .padding(.top)
+                
+                // summaryList에서 하나를 선택할 수 있는 기능
+                List(slowPostBoxViewModel.summaryList, id: \.self) { summary in
+                    Button(action: {
+                        slowPostBoxViewModel.selectedSummary = summary
+                    }) {
+                        Text(summary)
+                            .padding()
+                            .foregroundColor(slowPostBoxViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                            .fontWeight(slowPostBoxViewModel.selectedSummary == summary ? .bold : .regular)
+                    }
+                    .listRowBackground(postieColors.receivedLetterColor)
+                }
+                .scrollContentBackground(.hidden)
+                
+                HStack {
+                    Spacer()
+                    
+                    Button("취소") {
+                        slowPostBoxViewModel.closePopup()
+                    }
+                    .foregroundStyle(postieColors.tabBarTintColor)
+                    .padding()
+                    
+                    Spacer()
+                    
+                    Button("확인") {
+                        slowPostBoxViewModel.summary = slowPostBoxViewModel.selectedSummary
+                        slowPostBoxViewModel.showSummaryTextField()
+                        slowPostBoxViewModel.closePopup()
+                    }
+                    .foregroundStyle(slowPostBoxViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
+                    .fontWeight(slowPostBoxViewModel.selectedSummary.isEmpty ? .regular : .bold)
+                    .padding()
+                    .disabled(slowPostBoxViewModel.selectedSummary.isEmpty) // 선택해야 확인 버튼 활성화
+                    
+                    Spacer()
+                }
             }
         }
     }

--- a/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
@@ -181,8 +181,8 @@ struct SlowPostBoxView: View {
                 focusField = .summary
             }
         }
-        .sheet(isPresented: $slowPostBoxViewModel.showingPopup) {
-            PopupView
+        .sheet(isPresented: $slowPostBoxViewModel.showingSelectSummaryView) {
+            SelectSummaryView
                 .presentationDetents([.fraction(0.7)])
                 .interactiveDismissDisabled(true)
         }
@@ -356,7 +356,7 @@ extension SlowPostBoxView {
     }
     
     @ViewBuilder
-    private var PopupView: some View {
+    private var SelectSummaryView: some View {
         ZStack {
             postieColors.backGroundColor
                 .ignoresSafeArea()
@@ -386,7 +386,7 @@ extension SlowPostBoxView {
                     Spacer()
                     
                     Button("취소") {
-                        slowPostBoxViewModel.closePopup()
+                        slowPostBoxViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(postieColors.tabBarTintColor)
                     .padding()
@@ -396,7 +396,7 @@ extension SlowPostBoxView {
                     Button("확인") {
                         slowPostBoxViewModel.summary = slowPostBoxViewModel.selectedSummary
                         slowPostBoxViewModel.showSummaryTextField()
-                        slowPostBoxViewModel.closePopup()
+                        slowPostBoxViewModel.closeSelectSummaryView()
                     }
                     .foregroundStyle(slowPostBoxViewModel.selectedSummary.isEmpty ? postieColors.profileColor : postieColors.tintColor)
                     .fontWeight(slowPostBoxViewModel.selectedSummary.isEmpty ? .regular : .bold)

--- a/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
@@ -183,7 +183,7 @@ struct SlowPostBoxView: View {
         }
         .sheet(isPresented: $slowPostBoxViewModel.showingSelectSummaryView) {
             SelectSummaryView
-                .presentationDetents([.fraction(0.7)])
+                .presentationDetents([.medium])
                 .interactiveDismissDisabled(true)
         }
         .customOnChange(slowPostBoxViewModel.shouldDismiss) { shouldDismiss in
@@ -361,26 +361,39 @@ extension SlowPostBoxView {
             postieColors.backGroundColor
                 .ignoresSafeArea()
             
-            VStack {
+            VStack(spacing : 0) {
                 Text("요약 선택")
                     .font(.title)
                     .bold()
                     .foregroundStyle(postieColors.tintColor)
-                    .padding(.top)
+                    .padding()
+                    .padding(.top, 5)
                 
-                // summaryList에서 하나를 선택할 수 있는 기능
-                List(slowPostBoxViewModel.summaryList, id: \.self) { summary in
-                    Button(action: {
-                        slowPostBoxViewModel.selectedSummary = summary
-                    }) {
-                        Text(summary)
-                            .padding()
-                            .foregroundColor(slowPostBoxViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
-                            .fontWeight(slowPostBoxViewModel.selectedSummary == summary ? .bold : .regular)
+                ScrollView (showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        // summaryList에서 하나를 선택할 수 있는 기능
+                        ForEach(slowPostBoxViewModel.summaryList.indices, id: \.self) { index in
+                            let summary = slowPostBoxViewModel.summaryList[index]
+
+                            Button(action: {
+                                slowPostBoxViewModel.selectedSummary = summary
+                            }) {
+                                Text(summary)
+                                    .padding()
+                                    .foregroundColor(slowPostBoxViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)
+                                    .fontWeight(slowPostBoxViewModel.selectedSummary == summary ? .bold : .regular)
+                                    .frame(maxWidth: .infinity)
+                                    .background(postieColors.receivedLetterColor)
+                                    .cornerRadius(10)
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 5)
+                        }
                     }
-                    .listRowBackground(postieColors.receivedLetterColor)
                 }
                 .scrollContentBackground(.hidden)
+                
+                Spacer()
                 
                 HStack {
                     Spacer()

--- a/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
@@ -20,6 +20,7 @@ class AddLetterViewModel: ObservableObject {
     @Published var showingLetterImageFullScreenView: Bool = false
     @Published var showingTextRecognizerErrorAlert: Bool = false
     @Published var showingDismissAlert: Bool = false
+    @Published var showingPopup: Bool = false
     @Published var showingSummaryTextField: Bool = false
     @Published var showingSummaryAlert: Bool = false
     @Published var showingNotEnoughInfoAlert: Bool = false
@@ -62,6 +63,10 @@ class AddLetterViewModel: ObservableObject {
     func showLetterImageFullScreenView(index: Int) {
         selectedIndex = index
         showingLetterImageFullScreenView = true
+    }
+    
+    func showPopup() {
+        showingPopup = true
     }
 
     func showSummaryTextField() {
@@ -171,7 +176,8 @@ class AddLetterViewModel: ObservableObject {
 
             await MainActor.run {
                 summary = summaryResponse
-                showSummaryTextField()
+                showPopup()
+                //showSummaryTextField()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
@@ -20,7 +20,6 @@ class AddLetterViewModel: ObservableObject {
     @Published var showingLetterImageFullScreenView: Bool = false
     @Published var showingTextRecognizerErrorAlert: Bool = false
     @Published var showingDismissAlert: Bool = false
-    @Published var showingPopup: Bool = false
     @Published var showingSummaryTextField: Bool = false
     @Published var showingSummaryAlert: Bool = false
     @Published var showingNotEnoughInfoAlert: Bool = false
@@ -31,6 +30,9 @@ class AddLetterViewModel: ObservableObject {
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
     @Published var loadingText: String = "편지를 저장하고 있어요."
+    @Published var showingPopup: Bool = false
+    @Published var summaryList: [String] = []
+    @Published var selectedSummary: String = ""
 
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     var isReceived: Bool
@@ -67,6 +69,10 @@ class AddLetterViewModel: ObservableObject {
     
     func showPopup() {
         showingPopup = true
+    }
+    
+    func closePopup() {
+        showingPopup = false
     }
 
     func showSummaryTextField() {
@@ -169,15 +175,14 @@ class AddLetterViewModel: ObservableObject {
 
     func getSummary() async {
         do {
-            let summaryResponse = try await APIClient.shared.postRequestToAPI(
+            let summaries = try await APIClient.shared.postRequestToAPI(
                 title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 
             await MainActor.run {
-                summary = summaryResponse
+                summaryList = summaries
                 showPopup()
-                //showSummaryTextField()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
@@ -176,7 +176,6 @@ class AddLetterViewModel: ObservableObject {
     func getSummary() async {
         do {
             let summaries = try await APIClient.shared.postRequestToAPI(
-                title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 

--- a/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/AddLetterViewModel.swift
@@ -30,7 +30,7 @@ class AddLetterViewModel: ObservableObject {
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
     @Published var loadingText: String = "편지를 저장하고 있어요."
-    @Published var showingPopup: Bool = false
+    @Published var showingSelectSummaryView: Bool = false
     @Published var summaryList: [String] = []
     @Published var selectedSummary: String = ""
 
@@ -67,12 +67,12 @@ class AddLetterViewModel: ObservableObject {
         showingLetterImageFullScreenView = true
     }
     
-    func showPopup() {
-        showingPopup = true
+    func showSelectSummaryView() {
+        showingSelectSummaryView = true
     }
     
-    func closePopup() {
-        showingPopup = false
+    func closeSelectSummaryView() {
+        showingSelectSummaryView = false
     }
 
     func showSummaryTextField() {
@@ -181,7 +181,7 @@ class AddLetterViewModel: ObservableObject {
 
             await MainActor.run {
                 summaryList = summaries
-                showPopup()
+                showSelectSummaryView()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -197,7 +197,6 @@ class EditLetterViewModel: ObservableObject {
     func getSummary(isReceived: Bool) async {
         do {
             let summaries = try await APIClient.shared.postRequestToAPI(
-                title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -191,7 +191,7 @@ class EditLetterViewModel: ObservableObject {
             )
 
             await MainActor.run {
-                summary = summaryResponse
+//                summary = summaryResponse
                 showSummaryTextField()
             }
         } catch {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -32,7 +32,10 @@ class EditLetterViewModel: ObservableObject {
     @Published var selectedIndex: Int = 0
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
-    @Published var loadingText: String = ""
+    @Published var loadingText: String = "편지를 저장하고 있어요."
+    @Published var showingPopup: Bool = false
+    @Published var summaryList: [String] = []
+    @Published var selectedSummary: String = ""
 
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
 
@@ -52,6 +55,14 @@ class EditLetterViewModel: ObservableObject {
     func showLetterImageFullScreenView(index: Int) {
         selectedIndex = index
         showingLetterImageFullScreenView = true
+    }
+    
+    func showPopup() {
+        showingPopup = true
+    }
+    
+    func closePopup() {
+        showingPopup = false
     }
 
     func showSummaryTextField() {
@@ -185,14 +196,14 @@ class EditLetterViewModel: ObservableObject {
 
     func getSummary(isReceived: Bool) async {
         do {
-            let summaryResponse = try await APIClient.shared.postRequestToAPI(
+            let summaries = try await APIClient.shared.postRequestToAPI(
                 title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 
             await MainActor.run {
-//                summary = summaryResponse
-                showSummaryTextField()
+                summaryList = summaries
+                showPopup()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -33,7 +33,7 @@ class EditLetterViewModel: ObservableObject {
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
     @Published var loadingText: String = "편지를 저장하고 있어요."
-    @Published var showingPopup: Bool = false
+    @Published var showingSelectSummaryView: Bool = false
     @Published var summaryList: [String] = []
     @Published var selectedSummary: String = ""
 
@@ -57,12 +57,12 @@ class EditLetterViewModel: ObservableObject {
         showingLetterImageFullScreenView = true
     }
     
-    func showPopup() {
-        showingPopup = true
+    func showSelectSummaryView() {
+        showingSelectSummaryView = true
     }
     
-    func closePopup() {
-        showingPopup = false
+    func closeSelectSummaryView() {
+        showingSelectSummaryView = false
     }
 
     func showSummaryTextField() {
@@ -202,7 +202,7 @@ class EditLetterViewModel: ObservableObject {
 
             await MainActor.run {
                 summaryList = summaries
-                showPopup()
+                showSelectSummaryView()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
@@ -30,6 +30,9 @@ class SlowPostBoxViewModel: ObservableObject {
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
     @Published var loadingText: String = "편지를 저장하고 있어요."
+    @Published var showingPopup: Bool = false
+    @Published var summaryList: [String] = []
+    @Published var selectedSummary: String = ""
 
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     var isReceived: Bool
@@ -67,6 +70,14 @@ class SlowPostBoxViewModel: ObservableObject {
     func showLetterImageFullScreenView(index: Int) {
         selectedIndex = index
         showingLetterImageFullScreenView = true
+    }
+    
+    func showPopup() {
+        showingPopup = true
+    }
+    
+    func closePopup() {
+        showingPopup = false
     }
 
     func showSummaryTextField() {
@@ -171,14 +182,14 @@ class SlowPostBoxViewModel: ObservableObject {
 
     func getSummary() async {
         do {
-            let summaryResponse = try await APIClient.shared.postRequestToAPI(
+            let summaries = try await APIClient.shared.postRequestToAPI(
                 title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 
             await MainActor.run {
-                //summary = summaryResponse
-                showSummaryTextField()
+                summaryList = summaries
+                showPopup()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
@@ -30,7 +30,7 @@ class SlowPostBoxViewModel: ObservableObject {
     @Published var shouldDismiss: Bool = false
     @Published var isLoading: Bool = false
     @Published var loadingText: String = "편지를 저장하고 있어요."
-    @Published var showingPopup: Bool = false
+    @Published var showingSelectSummaryView: Bool = false
     @Published var summaryList: [String] = []
     @Published var selectedSummary: String = ""
 
@@ -72,12 +72,12 @@ class SlowPostBoxViewModel: ObservableObject {
         showingLetterImageFullScreenView = true
     }
     
-    func showPopup() {
-        showingPopup = true
+    func showSelectSummaryView() {
+        showingSelectSummaryView = true
     }
     
-    func closePopup() {
-        showingPopup = false
+    func closeSelectSummaryView() {
+        showingSelectSummaryView = false
     }
 
     func showSummaryTextField() {
@@ -188,7 +188,7 @@ class SlowPostBoxViewModel: ObservableObject {
 
             await MainActor.run {
                 summaryList = summaries
-                showPopup()
+                showSelectSummaryView()
             }
         } catch {
             await MainActor.run {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
@@ -183,7 +183,6 @@ class SlowPostBoxViewModel: ObservableObject {
     func getSummary() async {
         do {
             let summaries = try await APIClient.shared.postRequestToAPI(
-                title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
                 content: text
             )
 

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SlowPostBoxViewModel.swift
@@ -177,7 +177,7 @@ class SlowPostBoxViewModel: ObservableObject {
             )
 
             await MainActor.run {
-                summary = summaryResponse
+                //summary = summaryResponse
                 showSummaryTextField()
             }
         } catch {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
@@ -7,38 +7,6 @@
 
 import Foundation
 
-struct RequestBody: Codable {
-    let document: DocumentObject
-    let option: OptionObject
-}
-
-struct DocumentObject: Codable {
-    let title: String?
-    let content: String
-}
-
-struct OptionObject: Codable {
-    let texts: String
-    let segMinSize: Int
-    let includeAiFilters: Bool
-    let autoSentenceSplitter: Bool
-    let segCount: Int
-}
-
-struct ApiResponse: Codable {
-    let summary: String
-}
-
-struct APIErrorResponse: Codable {
-    let status: Int
-    let error: ErrorDetail
-}
-
-struct ErrorDetail: Codable {
-    let errorCode: String
-    let message: String
-}
-
 class APIClient {
     static let shared = APIClient()
     private init() {}
@@ -55,7 +23,7 @@ class APIClient {
         get { getValueOfPlistFile("SummaryApiKeys", "APIURL")}
     }
     
-    func postRequestToAPI(title: String, content: String) async throws -> [String] {
+    func postRequestToAPI(content: String) async throws -> [String] {
         guard let apiGatewayKey = apiGatewayKey else { return [] }
         guard let apiKey = apiKey else { return [] }
         guard let requestId = requestId else { return [] }
@@ -98,6 +66,7 @@ class APIClient {
                let result = json["result"] as? [String: Any],
                let text = result["text"] as? String {
                 
+                // 요약된 문장들에서 '-'만 빼고 배열에 넣음
                 let summaryList = text
                     .split(separator: "-")
                     .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -109,34 +78,5 @@ class APIClient {
         } catch {
             throw NSError(domain: "JSONParsingError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON response"])
         }
-    }
-}
-
-func errorMessage(_ statusCode: Int, errorCode: String) -> String {
-    switch (statusCode, errorCode) {
-    case (400, "E001"):
-        return "빈 문자열 or blank 문자"
-    case (400, "E002"):
-        return "UTF-8 인코딩 에러"
-    case (400, "E003"):
-        return "문장이 기준치보다 초과했을 경우"
-    case (400, "E100"):
-        return "유효한 문장이 부족한 경우"
-    case (400, "E101"):
-        return "ko, ja 가 아닌 경우"
-    case (400, "E102"):
-        return "general, news 가 아닌 경우"
-    case (400, "E103"):
-        return "request body의 json format이 유효하지 않거나 필수 파라미터가 누락된 경우"
-    case (400, "E415"):
-        return "content-type 에러"
-    case (400, "E900"):
-        return "예외처리가 안된 경우(Bad Request)"
-    case (500, "E501"):
-        return "엔드포인트 연결 실패"
-    case (500, "E900"):
-        return "예외처리가 안된 오류(Server Error)"
-    default:
-        return "알 수 없는 에러"
     }
 }

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
@@ -7,6 +7,15 @@
 
 import Foundation
 
+struct APIErrorResponse: Decodable {
+    let status: StatusDetail
+}
+
+struct StatusDetail: Decodable {
+    let code: String
+    let message: String
+}
+
 class APIClient {
     static let shared = APIClient()
     private init() {}
@@ -24,10 +33,10 @@ class APIClient {
     }
     
     func postRequestToAPI(content: String) async throws -> [String] {
-        guard let apiGatewayKey = apiGatewayKey else { return [] }
-        guard let apiKey = apiKey else { return [] }
-        guard let requestId = requestId else { return [] }
-        guard let apiEndpoint = apiUrl else { return [] }
+        guard let apiGatewayKey = apiGatewayKey,
+              let apiKey = apiKey,
+              let requestId = requestId,
+              let apiEndpoint = apiUrl else { return [] }
         guard let url = URL(string: apiEndpoint) else {
             throw URLError(.badURL)
         }
@@ -50,13 +59,37 @@ class APIClient {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: completionRequest, options: [])
         } catch {
-            throw NSError(domain: "SerializationError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to serialize JSON"])
+            throw NSError(
+                domain: "SerializationError",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to serialize JSON"])
         }
         
         let (data, response) = try await URLSession.shared.data(for: request)
         
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
+        }
+
+        if httpResponse.statusCode != 200 {
+            if let errorResponse = try? JSONDecoder().decode(APIErrorResponse.self, from: data) {
+                throw NSError(
+                    domain: "SummaryAPIError123",
+                    code: httpResponse.statusCode,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: httpResponse.statusCode,
+                        "errorCode": errorResponse.status.message
+                    ]
+                )
+            } else {
+                throw NSError(
+                    domain: "SummaryAPIError456",
+                    code: httpResponse.statusCode,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Unknown server error (statusCode: \(httpResponse.statusCode))"
+                    ]
+                )
+            }
         }
         
         do {
@@ -71,12 +104,80 @@ class APIClient {
                     .split(separator: "-")
                     .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                     .filter { !$0.isEmpty }
+                
+                print("요약 결과 : \(summaryList)")
+                guard !summaryList.isEmpty else {
+                    throw NSError(
+                        domain: "EmpytSummaryList",
+                        code: httpResponse.statusCode,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "Unknown server error (statusCode: \(httpResponse.statusCode))"
+                        ]
+                    )
+                }
                 return summaryList
             } else {
-                throw NSError(domain: "UnexpectedAPIResponse", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unexpected API response format"])
+                throw NSError(
+                    domain: "UnexpectedAPIResponse",
+                    code: httpResponse.statusCode,
+                    userInfo: [NSLocalizedDescriptionKey: "Unexpected API response format"]
+                )
             }
         } catch {
-            throw NSError(domain: "JSONParsingError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON response"])
+            throw NSError(
+                domain: "JSONParsingError",
+                code: httpResponse.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON response"]
+            )
         }
+    }
+}
+
+func errorMessage(_ code: String, message: String) -> String {
+    switch (code, message) {
+        case ("400", "E0006"):
+            return "유효하지 않은 JSON 형식입니다."
+        case ("400", "E0007"):
+            return "필수 파라미터가 누락되었습니다."
+        case ("400", "E0010"):
+            return "지원하지 않는 언어 코드를 사용했습니다."
+        case ("400", "E0011"):
+            return "텍스트가 너무 길거나 잘못된 형식입니다."
+        case ("400", "E0020"):
+            return "허용되지 않은 요청 옵션이 포함되어 있습니다."
+        case ("400", "E0099"):
+            return "알 수 없는 클라이언트 에러가 발생했습니다."
+        case ("400", "S4001"):
+            return "세션이 만료되었거나 유효하지 않습니다."
+        case ("400", "S4002"):
+            return "잘못된 인증 토큰이 포함되었습니다."
+        case ("403", "S4031"):
+            return "접근이 거부되었습니다(Forbidden)."
+        case ("404", "S4041"):
+            return "요청한 리소스를 찾을 수 없습니다(Not Found)."
+        case ("429", "S4290"):
+            return "요청 횟수 제한(Too Many Requests)을 초과했습니다."
+        case ("500", "C5001"):
+            return "서버 내부 처리 중 오류가 발생했습니다."
+        case ("500", "C5002"):
+            return "AI 모델 연동 중 예기치 못한 오류가 발생했습니다."
+        case ("500", "C5005"):
+            return "유효하지 않은 내부 모듈 호출입니다."
+        case ("500", "C5009"):
+            return "기타 서버 내부 오류가 발생했습니다."
+        case ("500", "S5001"):
+            return "시스템 내부에서 알 수 없는 오류가 발생했습니다."
+        case ("503", "S5031"):
+            return "서버가 일시적으로 과부하 상태입니다. 잠시 후 다시 시도해 주세요."
+        case ("504", "S5040"):
+            return "요청 처리 시간 초과(Gateway Timeout)로 인해 응답할 수 없습니다."
+        case (_, "S5999"):
+            return "알 수 없는 시스템 연동 오류가 발생했습니다."
+        case ("40000", "E0000"):
+            return "테스트 입니다."
+        case ("40004", "E0004"):
+            return "빈 텍스트 입니다."
+        default:
+            return "알 수 없는 에러가 발생했습니다. (statusCode: \(code), errorCode: \(message))"
     }
 }

--- a/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/SummaryApi.swift
@@ -55,11 +55,11 @@ class APIClient {
         get { getValueOfPlistFile("SummaryApiKeys", "APIURL")}
     }
     
-    func postRequestToAPI(title: String, content: String) async throws -> String {
-        guard let apiGatewayKey = apiGatewayKey else { return "" }
-        guard let apiKey = apiKey else { return "" }
-        guard let requestId = requestId else { return "" }
-        guard let apiEndpoint = apiUrl else { return "" }
+    func postRequestToAPI(title: String, content: String) async throws -> [String] {
+        guard let apiGatewayKey = apiGatewayKey else { return [] }
+        guard let apiKey = apiKey else { return [] }
+        guard let requestId = requestId else { return [] }
+        guard let apiEndpoint = apiUrl else { return [] }
         guard let url = URL(string: apiEndpoint) else {
             throw URLError(.badURL)
         }
@@ -98,13 +98,11 @@ class APIClient {
                let result = json["result"] as? [String: Any],
                let text = result["text"] as? String {
                 
-                // 문단을 랜덤으로 한개만 선택
-                let paragraphs = text.split(separator: "-").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                if let randomParagraph = paragraphs.randomElement() {
-                    return randomParagraph
-                } else {
-                    throw NSError(domain: "NoParagraphsError", code: 1, userInfo: [NSLocalizedDescriptionKey: "No paragraphs found in the summary"])
-                }
+                let summaryList = text
+                    .split(separator: "-")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                return summaryList
             } else {
                 throw NSError(domain: "UnexpectedAPIResponse", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unexpected API response format"])
             }

--- a/PJ3T3_Postie/Core/Setting/View/FirebaseTestView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/FirebaseTestView.swift
@@ -16,7 +16,7 @@ struct FirebaseTestView: View {
     private let profileBackgroundColor: Color = .gray
     private let signOutIconColor: Color = Color(uiColor: .lightGray)
     @State private var content: String = ""
-    @State private var summary: String = ""
+    @State private var summary: [String] = []
     @State private var isDeleteAccountDialogPresented = false
     @State private var showLoading = false
     @State private var showAlert = false
@@ -73,24 +73,24 @@ struct FirebaseTestView: View {
                         }
                     }
                     
-//                    Section("SummaryTest") {
-//                        
-//                        TextField("content", text: $content)
-//                        
-//                        Text(summary)
-//                        
-//                        Button(action: {
-//                            Task {
-//                                do {
-//                                    summary = try await APIClient.shared.postRequestToAPI(title: "", content: content)
-//                                } catch {
-//                                    summary = "에러 발생"
-//                                    Logger.firebase.info("에러 정보: \(error)")
-//                                }
-//                            }}, label: {
-//                                Text("요약하기")
-//                            })
-//                    }
+                    Section("SummaryTest") {
+                        
+                        TextField("텍스트를 입력하세요" , text: $content)
+                        
+                        Text(summary.joined(separator: "\n"))
+                        
+                        Button(action: {
+                            Task {
+                                do {
+                                    summary = try await APIClient.shared.postRequestToAPI(content: content)
+                                } catch {
+                                    summary = ["에러 발생"]
+                                    Logger.firebase.info("에러 정보: \(error)")
+                                }
+                            }}, label: {
+                                Text("요약하기")
+                            })
+                    }
                     
                     Section("Account") {
                         Button {

--- a/PJ3T3_Postie/Core/Setting/View/FirebaseTestView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/FirebaseTestView.swift
@@ -73,24 +73,24 @@ struct FirebaseTestView: View {
                         }
                     }
                     
-                    Section("SummaryTest") {
-                        
-                        TextField("content", text: $content)
-                        
-                        Text(summary)
-                        
-                        Button(action: {
-                            Task {
-                                do {
-                                    summary = try await APIClient.shared.postRequestToAPI(title: "", content: content)
-                                } catch {
-                                    summary = "에러 발생"
-                                    Logger.firebase.info("에러 정보: \(error)")
-                                }
-                            }}, label: {
-                                Text("요약하기")
-                            })
-                    }
+//                    Section("SummaryTest") {
+//                        
+//                        TextField("content", text: $content)
+//                        
+//                        Text(summary)
+//                        
+//                        Button(action: {
+//                            Task {
+//                                do {
+//                                    summary = try await APIClient.shared.postRequestToAPI(title: "", content: content)
+//                                } catch {
+//                                    summary = "에러 발생"
+//                                    Logger.firebase.info("에러 정보: \(error)")
+//                                }
+//                            }}, label: {
+//                                Text("요약하기")
+//                            })
+//                    }
                     
                     Section("Account") {
                         Button {

--- a/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
@@ -49,7 +49,7 @@ struct NoticeView: View {
                                     .ignoresSafeArea()
                                 
                                 VStack(alignment: .leading) {
-                                    Text("안녕하세요. 포스티 팀입니다.\n")
+                                    Text("안녕하세요. 포스티 팀입니다! 💌\n")
                                         .font(.callout)
                                     
 //                                    if let imageURL = post.imageURL {


### PR DESCRIPTION
## 개요
- in progress 
- close #16 #17
- 작업 요약
- SummaryApi에서 안쓰이는 코드를 정리했습니다.
- 긴글요약 UI가 변경되었습니다.

## 변경 사항
- 요약 UI 변경에 따른 요약 api 알고리즘 수정
- 기존 : API 호출 -> 문장요약 -> 전체 문장 받음 -> 그중 랜덤 하나 선택 -> 한줄 요약(content)에 사용
- 변경 : API 호출 -> 문장요약 -> 전체 문장 받음 -> 받은 전체 문장을 요약 팝업에 리스트로 띄우기 -> 그중하나 선택 -> 한줄 요약에 사용

## 공유사항(배운 것, 참고하면 좋을 것)
- 

## 스크린샷
작업후

https://github.com/user-attachments/assets/d177ed0c-2a23-4a59-b1d1-816eb2493a8a

## 전달사항
- 선택 UI 임시로 만든거라 추가 수정예정입니다 UI 상세수정은 미팅때 시간나면 자세하게 다뤄보죠
- 이번에도 리팩토링 , 디자인 작업이라 두 작업의 성격이 다른데, 코드가 겹치는 구간이라... 겹치는 구간을 따로 브랜치 만들고 PR 해본적이 없어서 일단은 한꺼번에 했습니다. 리팩토링부분이 적어서 사실상 긴글요약 UI, 알고리즘 변경정도로만 생각해주세용
