### PR TITLE
맵뷰 검색 텍스트필드에서 키보드 숨기기 버튼 오작동 에러 수정

### DIFF
--- a/PJ3T3_Postie/Core/Map/View/MapView.swift
+++ b/PJ3T3_Postie/Core/Map/View/MapView.swift
@@ -247,6 +247,7 @@ struct MapView: View {
                     
                     Button {
                         isSearchFocused = false
+                        hideKeyboard()
                     } label: {
                         Image(systemName: "keyboard.chevron.compact.down")
                     }


### PR DESCRIPTION
## 개요
- in progress
- close #25 
- 작업 요약

## 변경 사항
- 키보드 숨김 버튼에 함수가 연결 안돼있던 점 수정

## 공유사항(배운 것, 참고하면 좋을 것)
- 

## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
||||

## 전달사항
- 혹시 시뮬에서 키보드 내리는 버튼 뜨시나요?? 실기기에는 잘 뜨는데 시뮬에서는 안뜨네용..
- (한줄 PR... 다음엔 더 노력하겠습니다ㅠ)
