### PR TITLE
한줄 요약 텍스트 필드와 키보드가 겹치는 이슈 수정

### DIFF
--- a/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/AddLetterView.swift
@@ -24,6 +24,7 @@ struct AddLetterView: View {
     var isReceived: Bool
     var autoFilledName: String?
 
+    @State var extraBottomPadding: CGFloat = 0 
     @FocusState private var focusField: Field?
     @Environment(\.dismiss) var dismiss
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
@@ -47,15 +48,20 @@ struct AddLetterView: View {
             ThemeManager.themeColors[isThemeGroupButton].backGroundColor
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    letterInfoSection
-
-                    letterImagesSection
-
-                    letterTextSection
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        letterInfoSection
+                        
+                        letterImagesSection
+                        
+                        letterTextSection
+                    }
+                    .padding()
                 }
-                .padding()
+                .customOnChange(focusField) {
+                    scrollToBotton(to: $0, proxy: proxy)
+                }
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -165,6 +171,20 @@ struct AddLetterView: View {
         .customOnChange(addLetterViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
+            }
+        }
+    }
+    
+    private func scrollToBotton(to focusedField: Field?, proxy: ScrollViewProxy) {
+        guard focusedField == .summary else {
+            extraBottomPadding = 0
+            return
+        }
+        
+        extraBottomPadding = 10
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            withAnimation {
+                proxy.scrollTo("summaryField", anchor: .bottom) // 자동 스크롤
             }
         }
     }
@@ -325,6 +345,8 @@ extension AddLetterView {
                     .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .focused($focusField, equals: .summary)
+                    .padding(.bottom, extraBottomPadding)
+                    .id("summaryField")
             } else {
                 Label("편지를 요약해드릴게요.", systemImage: "text.quote.rtl")
                     .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].dividerColor)

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -23,6 +23,7 @@ struct EditLetterView: View {
 
     let letter: Letter
 
+    @State var extraBottomPadding: CGFloat = 0
     @FocusState private var focusField: Field?
     @Environment(\.dismiss) var dismiss
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
@@ -44,15 +45,20 @@ struct EditLetterView: View {
             ThemeManager.themeColors[isThemeGroupButton].backGroundColor
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    letterInfoSection
-
-                    letterImagesSection
-
-                    letterTextSection
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        letterInfoSection
+                        
+                        letterImagesSection
+                        
+                        letterTextSection
+                    }
+                    .padding()
                 }
-                .padding()
+                .customOnChange(focusField) {
+                    scrollToBotton(to: $0, proxy: proxy)
+                }
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -150,6 +156,20 @@ struct EditLetterView: View {
         .customOnChange(editLetterViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
+            }
+        }
+    }
+    
+    private func scrollToBotton(to focusedField: Field?, proxy: ScrollViewProxy) {
+        guard focusedField == .summary else {
+            extraBottomPadding = 0
+            return
+        }
+        
+        extraBottomPadding = 10
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            withAnimation {
+                proxy.scrollTo("summaryField", anchor: .bottom) // 자동 스크롤
             }
         }
     }
@@ -331,6 +351,8 @@ extension EditLetterView {
                     .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .focused($focusField, equals: .summary)
+                    .padding(.bottom, extraBottomPadding)
+                    .id("summaryField")
             } else {
                 Label("편지를 요약해드릴게요.", systemImage: "text.quote.rtl")
                     .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].dividerColor)

--- a/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/SlowPostBoxView.swift
@@ -22,7 +22,8 @@ struct SlowPostBoxView: View {
     }
 
     var isReceived: Bool
-
+    
+    @State var extraBottomPadding: CGFloat = 0
     @FocusState private var focusField: Field?
     @Environment(\.dismiss) var dismiss
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
@@ -45,15 +46,20 @@ struct SlowPostBoxView: View {
             ThemeManager.themeColors[isThemeGroupButton].backGroundColor
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    letterInfoSection
-
-                    letterImagesSection
-
-                    letterTextSection
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        letterInfoSection
+                        
+                        letterImagesSection
+                        
+                        letterTextSection
+                    }
+                    .padding()
                 }
-                .padding()
+                .customOnChange(focusField) {
+                    scrollToBotton(to: $0, proxy: proxy)
+                }
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -171,6 +177,20 @@ struct SlowPostBoxView: View {
         .customOnChange(slowPostBoxViewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
                 dismiss()
+            }
+        }
+    }
+        
+    private func scrollToBotton(to focusedField: Field?, proxy: ScrollViewProxy) {
+        guard focusedField == .summary else {
+            extraBottomPadding = 0
+            return
+        }
+        
+        extraBottomPadding = 10
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            withAnimation {
+                proxy.scrollTo("summaryField", anchor: .bottom) // 자동 스크롤
             }
         }
     }
@@ -324,6 +344,8 @@ extension SlowPostBoxView {
                     .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .focused($focusField, equals: .summary)
+                    .padding(.bottom, extraBottomPadding)
+                    .id("summaryField")
             } else {
                 Label("편지를 요약해드릴게요.", systemImage: "text.quote.rtl")
                     .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].dividerColor)
@@ -357,9 +379,9 @@ extension SlowPostBoxView {
                         ForEach(slowPostBoxViewModel.summaryList.indices, id: \.self) { index in
                             let summary = slowPostBoxViewModel.summaryList[index]
 
-                            Button(action: {
+                            Button {
                                 slowPostBoxViewModel.selectedSummary = summary
-                            }) {
+                            } label: {
                                 Text(summary)
                                     .padding()
                                     .foregroundColor(slowPostBoxViewModel.selectedSummary == summary ? postieColors.tintColor : postieColors.tabBarTintColor)


### PR DESCRIPTION
focusField가 summary일 때 summaryTextField에 추가 마진을 주고 스크롤뷰를 summaryTextField의 최하단으로 스크롤 시킴

<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- close #29  
- 작업: 요약 한줄 요약 텍스트 필드와 키보드가 겹치는 이슈 수정

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- ScrollView를 ScrollViewReader로 감싸고, 한 줄 요약 텍스트 필드가 활성화 되면 해당 필드에 추가 padding 부여 및 스크롤뷰를 최하단으로 자동 스크롤시켜 이슈 수정

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- 

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
||||

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-
