### PR TITLE
Remote Config 추가 및 앱 권장, 강제 업데이트 팝업 구분

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		9E25C2D12B7B8F8A00B04BA1 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E25C2D02B7B8F8A00B04BA1 /* CryptoUtils.swift */; };
 		9E28934C2B7E9314009A7D40 /* DeleteAccountButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E28934B2B7E9314009A7D40 /* DeleteAccountButtonView.swift */; };
 		9E46837C2B7BBBA100EFB90B /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E46837B2B7BBBA100EFB90B /* LoadingView.swift */; };
+		9E4ADAD22D5F584B008BE84A /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4ADAD12D5F584B008BE84A /* RemoteConfigManager.swift */; };
 		9E5889E32B72221B00B4AD20 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5889E22B72221B00B4AD20 /* SearchView.swift */; };
 		9E747CD32B88F4EE007DD0C3 /* InformationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E747CD22B88F4EE007DD0C3 /* InformationWebView.swift */; };
 		9E78F7452D05989C001460E6 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E78F7442D05989C001460E6 /* Utils.swift */; };
@@ -172,6 +173,7 @@
 		9E25C2D02B7B8F8A00B04BA1 /* CryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; };
 		9E28934B2B7E9314009A7D40 /* DeleteAccountButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountButtonView.swift; sourceTree = "<group>"; };
 		9E46837B2B7BBBA100EFB90B /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		9E4ADAD12D5F584B008BE84A /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		9E5889E22B72221B00B4AD20 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		9E747CD22B88F4EE007DD0C3 /* InformationWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationWebView.swift; sourceTree = "<group>"; };
 		9E78F7442D05989C001460E6 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 				9E9A8BE82B6B704E0072CB75 /* GoogleSignInHelper.swift */,
 				9E10CB1E2D2921790000F201 /* ImageAssetManager.swift */,
 				9E865CC42B839CC300CD7CAD /* NotificationManager.swift */,
+				9E4ADAD12D5F584B008BE84A /* RemoteConfigManager.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
 			);
 			path = Manager;
@@ -881,6 +884,7 @@
 				9E9F6AB62B5762E5003DFE83 /* HomeView.swift in Sources */,
 				9E9A8BEB2B6B79870072CB75 /* EmailLoginView.swift in Sources */,
 				E36587AB2B7E34E400584965 /* GroupedLetterViewModel.swift in Sources */,
+				9E4ADAD22D5F584B008BE84A /* RemoteConfigManager.swift in Sources */,
 				9E9A8BF12B6B85640072CB75 /* PostieUser.swift in Sources */,
 				0E29F0DB2B5FDC0F005B86FB /* NaverMap.swift in Sources */,
 				0E29F0E02B602E3D005B86FB /* MyCoord.swift in Sources */,

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct PJ3T3_PostieApp: App {
     
-    @Environment(\.scenePhase) var scenePhase
+    @Environment(\.scenePhase) private var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -53,6 +53,7 @@ struct PJ3T3_PostieApp: App {
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     
     @StateObject private var alertManager = AlertManager()
+    @StateObject private var remoteConfig = RemoteConfigManager()
     
     private var clientID: String? {
         get { getValueOfPlistFile("MapApiKeys", "NAVER_GEOCODE_ID") }
@@ -79,6 +80,7 @@ struct PJ3T3_PostieApp: App {
                     }
                 }
                 .environmentObject(alertManager)
+                .environmentObject(remoteConfig)
         }
     }
 }

--- a/PJ3T3_Postie/Core/Root/View/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/View/ContentView.swift
@@ -24,7 +24,6 @@ struct ContentView: View {
     @StateObject private var viewModel = AppViewModel()
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     @StateObject private var tabSelection = TabSelection()
-    @State var showUpdate: Bool = false
     
     init() {
         let tbAppearance: UITabBarAppearance = UITabBarAppearance()
@@ -129,7 +128,6 @@ struct ContentView: View {
                     return
                 }
                 
-                showUpdate = true
                 Logger.version.info("신규 버전 있음, alert 띄우자")
                 let isForceUpdate = remoteConfigManager.getBool(from: .is_force_update)
                 print("remoteConfigManager - force update: \(isForceUpdate)")

--- a/PJ3T3_Postie/Core/Root/View/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/View/ContentView.swift
@@ -18,6 +18,7 @@ import CoreLocation
 struct ContentView: View {
     
     @EnvironmentObject var alertManager: AlertManager
+    @EnvironmentObject var remoteConfigManager: RemoteConfigManager
     @ObservedObject var authViewModel = AuthManager.shared
     @StateObject private var viewModel = AppViewModel()
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
@@ -129,7 +130,9 @@ struct ContentView: View {
                 
                 showUpdate = true
                 Logger.version.info("신규 버전 있음, alert 띄우자")
-                alertManager.showUpdateAlert(isForceUpdate: false)
+                let isForceUpdate = remoteConfigManager.getBool(from: .is_force_update)
+                print("remoteConfigManager - force update: \(isForceUpdate)")
+                alertManager.showUpdateAlert(isForceUpdate: isForceUpdate)
             }
         }
     }

--- a/PJ3T3_Postie/Core/Root/View/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/View/ContentView.swift
@@ -17,6 +17,7 @@ import CoreLocation
 
 struct ContentView: View {
     
+    @Environment(\.scenePhase) var scenePhase
     @EnvironmentObject var alertManager: AlertManager
     @EnvironmentObject var remoteConfigManager: RemoteConfigManager
     @ObservedObject var authViewModel = AuthManager.shared
@@ -134,6 +135,11 @@ struct ContentView: View {
                 print("remoteConfigManager - force update: \(isForceUpdate)")
                 alertManager.showUpdateAlert(isForceUpdate: isForceUpdate)
             }
+        }
+        .customOnChange(scenePhase) { appStatus in
+            let isForceUpdate = remoteConfigManager.getBool(from: .is_force_update)
+            guard appStatus == .active, isForceUpdate  else { return }
+            alertManager.showUpdateAlert(isForceUpdate: isForceUpdate)
         }
     }
 //    func requestLocationPermission() {

--- a/PJ3T3_Postie/Core/Root/View/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/View/ContentView.swift
@@ -92,16 +92,6 @@ struct ContentView: View {
                 SplashScreenView()
             }
         }
-        .alert("업데이트 알림", isPresented: $showUpdate) {
-            let appleID = 6478052812 //테스트용 멜론 앱으로 연결: 415597317
-            if let url = URL(string: "itms-apps://itunes.apple.com/app/apple-store/\(appleID)") {
-                Link("업데이트", destination: url)
-            }
-            
-//            Button("나중에", role: .cancel) {}
-        } message: {
-            Text("새로운 버전 업데이트가 있어요! 더 나은 서비스를 위해 포스티를 업데이트 해 주세요.")
-        }
         .alert(alertManager.title, isPresented: $alertManager.isOneButtonAlertPresented) {
             if let button = alertManager.singleButton, let action = button.action, let title = button.title {
                 Button(title, role: button.role) {
@@ -132,12 +122,14 @@ struct ContentView: View {
         }
         .onAppear {
             Task {
-                if await AppStoreUpdateChecker.isNewVersionAvailable() {
-                    showUpdate = true
-                    Logger.firebase.info("신규 버전 있음, alert 띄우자")
-                } else {
-                    Logger.firebase.info("신규 버전 없음")
+                guard await AppStoreUpdateChecker.isNewVersionAvailable() else {
+                    Logger.version.info("신규 버전 없음")
+                    return
                 }
+                
+                showUpdate = true
+                Logger.version.info("신규 버전 있음, alert 띄우자")
+                alertManager.showUpdateAlert(isForceUpdate: false)
             }
         }
     }

--- a/PJ3T3_Postie/Manager/AlertManager.swift
+++ b/PJ3T3_Postie/Manager/AlertManager.swift
@@ -69,4 +69,35 @@ final class AlertManager: ObservableObject {
     func showEditErrorAlert() {
         showOneButtonAlert(title: "편지 수정 실패", message: "편지 수정에 실패했어요. 다시 시도해 주세요")
     }
+    
+    func showUpdateAlert(isForceUpdate: Bool) {
+        let appleID = 6478052812 //테스트용 멜론 앱으로 연결: 415597317
+        let appStoreURL = "itms-apps://itunes.apple.com/app/apple-store/\(appleID)"
+        let alertTitle = "업데이트 알림"
+        let alertMessage = "새로운 버전 업데이트가 있어요! 더 나은 서비스를 위해 포스티를 업데이트 해 주세요."
+        let updateButtonLabel = "업데이트"
+        let updateAction = {
+            if let url = URL(string: appStoreURL) {
+                UIApplication.shared.open(url)
+            }
+        }
+        
+        if isForceUpdate {
+            showOneButtonAlert(
+                title: alertTitle,
+                message: alertMessage,
+                buttonLabel: updateButtonLabel,
+                buttonAction: updateAction
+            )
+        } else {
+            showTwoButtonAlert(
+                title: alertTitle,
+                message: alertMessage,
+                leftButtonLabel: "나중에",
+                leftButtonRole: .cancel,
+                rightButtonLabel: updateButtonLabel,
+                rightButtonAction: updateAction
+            )
+        }
+    }
 }

--- a/PJ3T3_Postie/Manager/RemoteConfigManager.swift
+++ b/PJ3T3_Postie/Manager/RemoteConfigManager.swift
@@ -22,7 +22,7 @@ final class RemoteConfigManager: ObservableObject {
     }
     
     private func fetchConfig() {
-        settings.minimumFetchInterval = 0
+        settings.minimumFetchInterval = 3600
         remoteConfig.configSettings = settings
         
         remoteConfig.fetch() { [weak self] status, error in

--- a/PJ3T3_Postie/Manager/RemoteConfigManager.swift
+++ b/PJ3T3_Postie/Manager/RemoteConfigManager.swift
@@ -1,0 +1,53 @@
+//
+//  RemoteConfigManager.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/14/25.
+//
+
+import Foundation
+import FirebaseRemoteConfig
+import OSLog
+
+enum RemoteConfigKeys: String {
+    case is_force_update
+}
+
+final class RemoteConfigManager: ObservableObject {
+    let remoteConfig = RemoteConfig.remoteConfig()
+    let settings = RemoteConfigSettings()
+    
+    public init() {
+        fetchConfig()
+    }
+    
+    private func fetchConfig() {
+        settings.minimumFetchInterval = 0
+        remoteConfig.configSettings = settings
+        
+        remoteConfig.fetch() { [weak self] status, error in
+            guard error == nil, status == .success else { return }
+            
+            self?.remoteConfig.activate { isChanged, error in
+                guard error == nil else { return }
+                Logger.firebase.log("RemoteConfig fetched and activated: \(isChanged)")
+            }
+        }
+    }
+    
+    func getBool(from key: RemoteConfigKeys) -> Bool {
+        return remoteConfig.configValue(forKey: key.rawValue).boolValue
+    }
+    
+    func getString(from key: RemoteConfigKeys) -> String? {
+        return remoteConfig.configValue(forKey: key.rawValue).stringValue
+    }
+    
+    func getNumber(from key: RemoteConfigKeys) -> NSNumber {
+        return remoteConfig.configValue(forKey: key.rawValue).numberValue
+    }
+    
+    func getJson(from key: RemoteConfigKeys) -> [String: Any]? {
+        return remoteConfig.configValue(forKey: key.rawValue).jsonValue as? [String: Any]
+    }
+}


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- close #31  
- 작업 요약: 앱 내 각종 설정을 위한 리모트 컨피그 탑재

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 앱에서 리모트 컨피그를 통한 플래그를 사용할 수 있습니다. 출시 이후에도 앱 내 환경변수를 원격으로 수정할 수 있습니다.
- 리모트 컨피그를 활용하여 강제 업데이트와 권장 업데이트를 구분할 수 있습니다.
  - 강제 업데이트: 업데이트를 하지 않으면 앱을 사용할 수 없습니다.
  - 권장 업데이트: 나중에 버튼을 누르면 앱을 재시작할 때 까지 다시 팝업이 나타나지 않습니다.

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [파이어베이스 공식 문서](https://firebase.google.com/docs/remote-config/get-started?hl=ko&platform=ios)
- [SwiftUI에서 앱 백그라운드, 포어그라운드 여부 확인](https://trashblog.tistory.com/166)
- [[iOS - swift] Firebase Remote Config 사용 방법 (FirebaseRemoteConfig)](https://ios-development.tistory.com/1341)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|권장 업데이트|나중에 버튼이 없습니다.|<img width="216" src="https://github.com/user-attachments/assets/9e259956-78e1-43d9-8c8a-5bfacf90c261">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 테스트 방법
1. 본 브랜치로 전환
2. Firebase Remote Config의 is_force_update 값을 true로 변경 및 변경사항 게시
3. RemoteConfigManager의 fetchConfig 함수 내부의 minimumFetchInterval 값을 0으로 수정
4. 앱 버전을 1.0.4보다 작게 변경한다음 앱 빌드
5. 강제 업데이트 팝업 노출되는것을 확인
6. Firebase Remote Config의 is_force_update 값을 false로 변경 및 변경사항 게시
7. 권장 업데이트 팝업 노출되는것을 확인

- 테스트 후 is_force_update 값은 false로 저장 해 주세요.