### PR TITLE
수정 취소 버튼 추가 및 변경사항 확인 후 저장

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -26,9 +26,9 @@
 		9E0FA1232B54D27C001CEEB9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E0FA1222B54D27C001CEEB9 /* Preview Assets.xcassets */; };
 		9E0FA12A2B54D2EF001CEEB9 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 9E0FA1292B54D2EF001CEEB9 /* README.md */; };
 		9E0FA12C2B54D2FC001CEEB9 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 9E0FA12B2B54D2FC001CEEB9 /* .gitignore */; };
-		9E10CB212D2E85CE0000F201 /* AlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E10CB202D2E85CE0000F201 /* AlertManager.swift */; };
 		9E10CB1D2D291A600000F201 /* Appdelegate+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E10CB1C2D291A600000F201 /* Appdelegate+extensions.swift */; };
 		9E10CB1F2D2921790000F201 /* ImageAssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E10CB1E2D2921790000F201 /* ImageAssetManager.swift */; };
+		9E10CB212D2E85CE0000F201 /* AlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E10CB202D2E85CE0000F201 /* AlertManager.swift */; };
 		9E1C7DF82BE8B4370075EA58 /* PJ3T3-Postie-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9E1C7DF42BE8B4370075EA58 /* PJ3T3-Postie-Info.plist */; };
 		9E1C7DF92BE8B4370075EA58 /* MapApiKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9E1C7DF52BE8B4370075EA58 /* MapApiKeys.plist */; };
 		9E1C7DFA2BE8B4370075EA58 /* SummaryApiKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9E1C7DF62BE8B4370075EA58 /* SummaryApiKeys.plist */; };
@@ -160,9 +160,9 @@
 		9E0FA1222B54D27C001CEEB9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9E0FA1292B54D2EF001CEEB9 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		9E0FA12B2B54D2FC001CEEB9 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
-		9E10CB202D2E85CE0000F201 /* AlertManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManager.swift; sourceTree = "<group>"; };
 		9E10CB1C2D291A600000F201 /* Appdelegate+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Appdelegate+extensions.swift"; sourceTree = "<group>"; };
 		9E10CB1E2D2921790000F201 /* ImageAssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAssetManager.swift; sourceTree = "<group>"; };
+		9E10CB202D2E85CE0000F201 /* AlertManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManager.swift; sourceTree = "<group>"; };
 		9E1C7DF42BE8B4370075EA58 /* PJ3T3-Postie-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "PJ3T3-Postie-Info.plist"; sourceTree = "<group>"; };
 		9E1C7DF52BE8B4370075EA58 /* MapApiKeys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MapApiKeys.plist; sourceTree = "<group>"; };
 		9E1C7DF62BE8B4370075EA58 /* SummaryApiKeys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SummaryApiKeys.plist; sourceTree = "<group>"; };
@@ -1094,7 +1094,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1115,7 +1115,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eunicej927.postie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1140,7 +1140,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = X4Z4N42YGF;
@@ -1159,7 +1159,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eunicej927.postie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -165,6 +165,7 @@ struct EditLetterView: View {
             } label: {
                 Text("취소")
             }
+            
             Button {
                 dismiss()
             } label: {
@@ -179,6 +180,7 @@ struct EditLetterView: View {
             } label: {
                 Text("취소")
             }
+            
             Button {
                 Task {
                     await editLetterViewModel.updateLetter(letter: letter)

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -160,26 +160,26 @@ struct EditLetterView: View {
             }
         }
         .alert("편지 수정을 그만할까요?", isPresented: $editLetterViewModel.showingDismissAlert) {
-            Button(role: .destructive) {
-                dismiss()
-            } label: {
-                Text("그만 할래요")
-            }
-            Button(role: .cancel) {
+            Button {
                 
             } label: {
-                Text("계속 쓸래요")
+                Text("취소")
+            }
+            Button {
+                dismiss()
+            } label: {
+                Text("확인")
             }
         } message: {
             Text("변경된 내용이 저장되지 않아요!")
         }
         .alert("변경 사항을 저장 할까요?", isPresented: $editLetterViewModel.showingSaveAlert) {
-            Button(role: .destructive) {
+            Button {
 
             } label: {
                 Text("취소")
             }
-            Button(role: .cancel) {
+            Button {
                 Task {
                     await editLetterViewModel.updateLetter(letter: letter)
                 }

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -63,6 +63,16 @@ struct EditLetterView: View {
                     .bold()
                     .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].tintColor)
             }
+            
+            ToolbarItemGroup(placement: .topBarLeading) {
+                Button {
+                    Task {
+                        dismiss()
+                    }
+                } label : {
+                    Text("취소")
+                }
+            }
 
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -55,6 +55,7 @@ struct EditLetterView: View {
                 .padding()
             }
         }
+        .interactiveDismissDisabled(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(ThemeManager.themeColors[isThemeGroupButton].backGroundColor, for: .navigationBar)
         .toolbar {
@@ -66,10 +67,8 @@ struct EditLetterView: View {
             
             ToolbarItemGroup(placement: .topBarLeading) {
                 Button {
-                    Task {
-                        dismiss()
-                    }
-                } label : {
+                    editLetterViewModel.showDismissAlert()
+                } label: {
                     Text("취소")
                 }
             }
@@ -161,6 +160,20 @@ struct EditLetterView: View {
             if shouldDismiss {
                 dismiss()
             }
+        }
+        .alert("수정사항을 취소하실 건가요?", isPresented: $editLetterViewModel.showingDismissAlert) {
+            Button(role: .destructive) {
+                dismiss()
+            } label: {
+                Text("그만 할래요")
+            }
+            Button(role: .cancel) {
+                
+            } label: {
+                Text("계속 쓸래요")
+            }
+        } message: {
+            Text("변경된 내용이 저장되지 않아요!")
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -67,11 +67,7 @@ struct EditLetterView: View {
             
             ToolbarItemGroup(placement: .topBarLeading) {
                 Button {
-                    if editLetterViewModel.isEdited() {
-                        editLetterViewModel.showDismissAlert()
-                    } else {
-                        dismiss()
-                    }
+                    editLetterViewModel.isEdited() ? editLetterViewModel.showDismissAlert() : dismiss()
                 } label: {
                     Text("취소")
                 }
@@ -79,13 +75,7 @@ struct EditLetterView: View {
 
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
-                    Task {
-                        if editLetterViewModel.isEdited() {
-                            editLetterViewModel.showSaveAlert()
-                        } else {
-                            dismiss()
-                        }
-                    }
+                    editLetterViewModel.isEdited() ? editLetterViewModel.showSaveAlert() : dismiss()
                 } label : {
                     Text("완료")
                 }
@@ -125,7 +115,6 @@ struct EditLetterView: View {
         }
         .onAppear {
             editLetterViewModel.syncViewModelProperties(letter: letter)
-            editLetterViewModel.initViewModelProperties(letter: letter)
             editLetterViewModel.setAlertManager(alertManager: alertManager)
         }
         .confirmationDialog("편지 사진 가져오기", isPresented: $editLetterViewModel.showingImageConfirmationDialog, titleVisibility: .visible) {
@@ -170,7 +159,7 @@ struct EditLetterView: View {
                 dismiss()
             }
         }
-        .alert("수정사항을 취소하실 건가요?", isPresented: $editLetterViewModel.showingDismissAlert) {
+        .alert("편지 수정을 그만할까요?", isPresented: $editLetterViewModel.showingDismissAlert) {
             Button(role: .destructive) {
                 dismiss()
             } label: {
@@ -184,21 +173,21 @@ struct EditLetterView: View {
         } message: {
             Text("변경된 내용이 저장되지 않아요!")
         }
-        .alert("이렇게 저장 할까요?", isPresented: $editLetterViewModel.showingSaveAlert) {
+        .alert("변경 사항을 저장 할까요?", isPresented: $editLetterViewModel.showingSaveAlert) {
+            Button(role: .destructive) {
+
+            } label: {
+                Text("취소")
+            }
             Button(role: .cancel) {
                 Task {
                     await editLetterViewModel.updateLetter(letter: letter)
                 }
             } label: {
-                Text("저장 할래요")
-            }
-            Button(role: .destructive) {
-                
-            } label: {
-                Text("계속 쓸래요")
+                Text("확인")
             }
         } message: {
-            Text("수정사항에 따라 시간이 조금 걸릴 수 있어요.")
+            Text("편지의 내용이 수정 되었어요!")
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
+++ b/PJ3T3_Postie/Core/Letter/View/EditLetterView.swift
@@ -67,7 +67,11 @@ struct EditLetterView: View {
             
             ToolbarItemGroup(placement: .topBarLeading) {
                 Button {
-                    editLetterViewModel.showDismissAlert()
+                    if editLetterViewModel.isEdited() {
+                        editLetterViewModel.showDismissAlert()
+                    } else {
+                        dismiss()
+                    }
                 } label: {
                     Text("취소")
                 }
@@ -76,7 +80,11 @@ struct EditLetterView: View {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
                     Task {
-                        await editLetterViewModel.updateLetter(letter: letter)
+                        if editLetterViewModel.isEdited() {
+                            editLetterViewModel.showSaveAlert()
+                        } else {
+                            dismiss()
+                        }
                     }
                 } label : {
                     Text("완료")
@@ -117,6 +125,7 @@ struct EditLetterView: View {
         }
         .onAppear {
             editLetterViewModel.syncViewModelProperties(letter: letter)
+            editLetterViewModel.initViewModelProperties(letter: letter)
             editLetterViewModel.setAlertManager(alertManager: alertManager)
         }
         .confirmationDialog("편지 사진 가져오기", isPresented: $editLetterViewModel.showingImageConfirmationDialog, titleVisibility: .visible) {
@@ -174,6 +183,22 @@ struct EditLetterView: View {
             }
         } message: {
             Text("변경된 내용이 저장되지 않아요!")
+        }
+        .alert("이렇게 저장 할까요?", isPresented: $editLetterViewModel.showingSaveAlert) {
+            Button(role: .cancel) {
+                Task {
+                    await editLetterViewModel.updateLetter(letter: letter)
+                }
+            } label: {
+                Text("저장 할래요")
+            }
+            Button(role: .destructive) {
+                
+            } label: {
+                Text("계속 쓸래요")
+            }
+        } message: {
+            Text("수정사항에 따라 시간이 조금 걸릴 수 있어요.")
         }
     }
 }

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -34,20 +34,17 @@ class EditLetterViewModel: ObservableObject {
     @Published var selectedSummary: String = ""
     @Published var showingDismissAlert: Bool = false
     @Published var showingSaveAlert: Bool = false
+    @Published var newImages: [UIImage] = []
+    @Published var fullPathsAndUrls: [FullPathAndUrl] = []
     
     private var alertManager: AlertManager?
+    private var originalLetter: Letter? = nil
+    private var originalImagesCount: Int = 0
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
+    var deleteCandidatesFromFullPathsANdUrls: [FullPathAndUrl] = []
     
     func setAlertManager(alertManager: AlertManager) {
         self.alertManager = alertManager
-    }
-    
-    func showDismissAlert() {
-        showingDismissAlert = true
-    }
-
-    func showSaveAlert() {
-        showingSaveAlert = true
     }
 
     func removeImage(at index: Int) {
@@ -75,9 +72,13 @@ class EditLetterViewModel: ObservableObject {
     func showSummaryTextField() {
         showingSummaryTextField = true
     }
+    
+    func showDismissAlert() {
+        showingDismissAlert = true
+    }
 
-    private func dismissView() {
-        shouldDismiss = true
+    func showSaveAlert() {
+        showingSaveAlert = true
     }
 
     func showConfirmationDialog() {
@@ -88,29 +89,11 @@ class EditLetterViewModel: ObservableObject {
         showingSummaryConfirmationDialog = true
     }
     
-    // MARK: - checkIsEdited
-    
-    private var originalLetter: Letter? = nil
-    private var originalImagesCount: Int = 0
-
-    // 변경 여부 확인 함수
-    func isEdited() -> Bool {
-        return sender != originalLetter?.writer ||
-        receiver != originalLetter?.recipient ||
-        date != originalLetter?.date ||
-        text != originalLetter?.text ||
-        summary != originalLetter?.summary ||
-        originalImagesCount != fullPathsAndUrls.count || // 그 외의 이미지 변경점 확인
-        !newImages.isEmpty // 이미지 x -> 이미지 추가. 변경점 확인
+    private func dismissView() {
+        shouldDismiss = true
     }
 
     // MARK: - Images
-
-    @Published var newImages: [UIImage] = []
-
-    @Published var fullPathsAndUrls: [FullPathAndUrl] = []
-    var deleteCandidatesFromFullPathsANdUrls: [FullPathAndUrl] = []
-
     private func removeImages(docId: String, deleteCandidates: [FullPathAndUrl]) async throws {
         for deleteCandidate in deleteCandidatesFromFullPathsANdUrls {
             try await StorageManager.shared.deleteItemAsync(fullPath: deleteCandidate.fullPath)
@@ -210,6 +193,19 @@ class EditLetterViewModel: ObservableObject {
         // 편지 수정 완료 시 비교할 원본 값
         originalLetter = letter
         originalImagesCount = fullPathsAndUrls.count
+    }
+    
+    //MARK: - Other functions
+    
+    /// 편지 수정 여부 확인 함수
+    func isEdited() -> Bool {
+        return sender != originalLetter?.writer ||
+        receiver != originalLetter?.recipient ||
+        date != originalLetter?.date ||
+        text != originalLetter?.text ||
+        summary != originalLetter?.summary ||
+        fullPathsAndUrls.count != originalImagesCount || // 그 외의 이미지 변경점 확인
+        !newImages.isEmpty // 이미지 x -> 이미지 추가. 변경점 확인
     }
 
     func getSummary(isReceived: Bool) async {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -34,42 +34,7 @@ class EditLetterViewModel: ObservableObject {
     @Published var selectedSummary: String = ""
     @Published var showingDismissAlert: Bool = false
     @Published var showingSaveAlert: Bool = false
-
-    private var initSender: String = ""
-    private var initReceiver: String = ""
-    private var initDate: Date = Date()
-    private var initText: String = ""
-    private var initSummary: String = ""
-    private var initImagesCount: Int = 0
-
-    func initViewModelProperties(letter: Letter) {
-        // 현재 값 저장
-        sender = letter.writer
-        receiver = letter.recipient
-        date = letter.date
-        text = letter.text
-        summary = letter.summary
-
-        // 원본 값 저장
-        initSender = letter.writer
-        initReceiver = letter.recipient
-        initDate = letter.date
-        initText = letter.text
-        initSummary = letter.summary
-        initImagesCount = fullPathsAndUrls.count
-    }
-
-    // 변경 여부 확인 함수
-    func isEdited() -> Bool {
-        return sender != initSender ||
-            receiver != initReceiver ||
-            date != initDate ||
-            text != initText ||
-            summary != initSummary ||
-            !newImages.isEmpty || // 이미지 x -> 이미지 추가. 변경점 확인
-            initImagesCount != fullPathsAndUrls.count // 그 외의 이미지 변경점 확인
-    }
-
+    
     private var alertManager: AlertManager?
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     
@@ -121,6 +86,26 @@ class EditLetterViewModel: ObservableObject {
 
     func showSummaryConfirmationDialog() {
         showingSummaryConfirmationDialog = true
+    }
+    
+    // MARK: - checkIsEdited
+    
+    private var initSender: String = ""
+    private var initReceiver: String = ""
+    private var initDate: Date = Date()
+    private var initText: String = ""
+    private var initSummary: String = ""
+    private var initImagesCount: Int = 0
+
+    // 변경 여부 확인 함수
+    func isEdited() -> Bool {
+        return sender != initSender ||
+            receiver != initReceiver ||
+            date != initDate ||
+            text != initText ||
+            summary != initSummary ||
+            !newImages.isEmpty || // 이미지 x -> 이미지 추가. 변경점 확인
+            initImagesCount != fullPathsAndUrls.count // 그 외의 이미지 변경점 확인
     }
 
     // MARK: - Images
@@ -225,6 +210,14 @@ class EditLetterViewModel: ObservableObject {
 
         guard let urls = letter.imageURLs, let fullPaths = letter.imageFullPaths else { return }
         fullPathsAndUrls = zip(urls, fullPaths).map { FullPathAndUrl(fullPath: $0.1, url: $0.0) }
+        
+        // 편지 수정 완료 시 비교할 원본 값
+        initSender = letter.writer
+        initReceiver = letter.recipient
+        initDate = letter.date
+        initText = letter.text
+        initSummary = letter.summary
+        initImagesCount = fullPathsAndUrls.count
     }
 
     func getSummary(isReceived: Bool) async {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -32,12 +32,17 @@ class EditLetterViewModel: ObservableObject {
     @Published var showingSelectSummaryView: Bool = false
     @Published var summaryList: [String] = []
     @Published var selectedSummary: String = ""
+    @Published var showingDismissAlert: Bool = false
 
     private var alertManager: AlertManager?
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     
     func setAlertManager(alertManager: AlertManager) {
         self.alertManager = alertManager
+    }
+    
+    func showDismissAlert() {
+        showingDismissAlert = true
     }
 
     func removeImage(at index: Int) {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -90,22 +90,18 @@ class EditLetterViewModel: ObservableObject {
     
     // MARK: - checkIsEdited
     
-    private var initSender: String = ""
-    private var initReceiver: String = ""
-    private var initDate: Date = Date()
-    private var initText: String = ""
-    private var initSummary: String = ""
-    private var initImagesCount: Int = 0
+    private var originalLetter: Letter? = nil
+    private var originalImagesCount: Int = 0
 
     // 변경 여부 확인 함수
     func isEdited() -> Bool {
-        return sender != initSender ||
-            receiver != initReceiver ||
-            date != initDate ||
-            text != initText ||
-            summary != initSummary ||
-            !newImages.isEmpty || // 이미지 x -> 이미지 추가. 변경점 확인
-            initImagesCount != fullPathsAndUrls.count // 그 외의 이미지 변경점 확인
+        return sender != originalLetter?.writer ||
+        receiver != originalLetter?.recipient ||
+        date != originalLetter?.date ||
+        text != originalLetter?.text ||
+        summary != originalLetter?.summary ||
+        originalImagesCount != fullPathsAndUrls.count || // 그 외의 이미지 변경점 확인
+        !newImages.isEmpty // 이미지 x -> 이미지 추가. 변경점 확인
     }
 
     // MARK: - Images
@@ -212,12 +208,8 @@ class EditLetterViewModel: ObservableObject {
         fullPathsAndUrls = zip(urls, fullPaths).map { FullPathAndUrl(fullPath: $0.1, url: $0.0) }
         
         // 편지 수정 완료 시 비교할 원본 값
-        initSender = letter.writer
-        initReceiver = letter.recipient
-        initDate = letter.date
-        initText = letter.text
-        initSummary = letter.summary
-        initImagesCount = fullPathsAndUrls.count
+        originalLetter = letter
+        originalImagesCount = fullPathsAndUrls.count
     }
 
     func getSummary(isReceived: Bool) async {

--- a/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Letter/ViewModel/EditLetterViewModel.swift
@@ -33,6 +33,42 @@ class EditLetterViewModel: ObservableObject {
     @Published var summaryList: [String] = []
     @Published var selectedSummary: String = ""
     @Published var showingDismissAlert: Bool = false
+    @Published var showingSaveAlert: Bool = false
+
+    private var initSender: String = ""
+    private var initReceiver: String = ""
+    private var initDate: Date = Date()
+    private var initText: String = ""
+    private var initSummary: String = ""
+    private var initImagesCount: Int = 0
+
+    func initViewModelProperties(letter: Letter) {
+        // 현재 값 저장
+        sender = letter.writer
+        receiver = letter.recipient
+        date = letter.date
+        text = letter.text
+        summary = letter.summary
+
+        // 원본 값 저장
+        initSender = letter.writer
+        initReceiver = letter.recipient
+        initDate = letter.date
+        initText = letter.text
+        initSummary = letter.summary
+        initImagesCount = fullPathsAndUrls.count
+    }
+
+    // 변경 여부 확인 함수
+    func isEdited() -> Bool {
+        return sender != initSender ||
+            receiver != initReceiver ||
+            date != initDate ||
+            text != initText ||
+            summary != initSummary ||
+            !newImages.isEmpty || // 이미지 x -> 이미지 추가. 변경점 확인
+            initImagesCount != fullPathsAndUrls.count // 그 외의 이미지 변경점 확인
+    }
 
     private var alertManager: AlertManager?
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
@@ -43,6 +79,10 @@ class EditLetterViewModel: ObservableObject {
     
     func showDismissAlert() {
         showingDismissAlert = true
+    }
+
+    func showSaveAlert() {
+        showingSaveAlert = true
     }
 
     func removeImage(at index: Int) {


### PR DESCRIPTION
## 개요
- in progress
- close #27 
- 작업 요약

## 변경 사항
- 수정 취소 버튼 추가
- 에딧뷰 스크롤로 닫기 비활성화
- 변경사항 확인 후, 변경 사항 있을때만 취소, 저장 알림

## 공유사항(배운 것, 참고하면 좋을 것)
- 

## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
||나중에 버튼이 없습니다.|<img width="216" src="https://github.com/user-attachments/assets/73303a2e-e7bf-4279-a59b-eed8947df7b0"> <img width="216" src="https://github.com/user-attachments/assets/55344c77-59d9-4a6c-baea-007f98ff5231">|



## 전달사항
- 지금 a.jpg, b.jpg 상태에서 b.jpg 삭제 후 다시 b.jpg 추가 (사진 삭제 후 동일 사진 추가) 상태 추적이 안돼서 이런경우는 변경된걸로 떠서 저장됩니다. 그런데 이럴 경우가 적을것으로 판단해서 나중에 시간 되면 가능한지 정보 검색해보고 수정해볼게요
