### PR TITLE
우체통, 우체국 카테고리 버튼 클릭시 지도 업데이트 되지 않는 버그 수정

### DIFF
--- a/PJ3T3_Postie/Core/Map/View/MapView.swift
+++ b/PJ3T3_Postie/Core/Map/View/MapView.swift
@@ -28,7 +28,7 @@ struct MapView: View {
     @State private var isSideMenuOpen = false
     @State private var isKeyboardVisible = false
     @State private var searchText = ""
-    @State private var showButton = false
+    @State private var showResearchButton = false
     @State private var checkMyLocation = false
     @State private var checkAlert = false
     @State private var checkAllow = false
@@ -57,9 +57,10 @@ struct MapView: View {
                     
                     HStack(spacing: 10) {
                         ForEach(0...1, id: \.self) { index in
-                            Button(action: {
+                            Button {
                                 selectedButtonIndex = index
-                            }) {
+                                fetchInCurrentLocation()
+                            } label: {
                                 ZStack {
                                     Rectangle()
                                         .foregroundColor(.clear)
@@ -142,22 +143,12 @@ struct MapView: View {
                             .ignoresSafeArea(.all, edges: .top)
                         
                         VStack {
-                            Button(action: {
+                            Button {
                                 Logger.map.info("현재 위치에서 \(name[selectedButtonIndex]) 찾기 버튼 눌림")
-                                
-                                locationManager.stopUpdatingLocation() // 현재 위치 추적 금지
-                                
-                                coord = MyCoord(coordinator.cameraLocation?.lat ?? coord.lat, coordinator.cameraLocation?.lng ?? coord.lng)
-                                
-                                coordinator.updateMapView(coord: coord, overlay: false)
-                                
-                                officeInfoServiceAPI.fetchData(postDivType: selectedButtonIndex + 1, postLatitude: coord.lat, postLongitude: coord.lng)
-                                
-                                // 버튼 비활성화
-                                showButton = false
+                                fetchInCurrentLocation()
                                 // coordinator.cameraLocation 값이 바뀌면
-                            }) {
-                                if showButton {
+                            } label: {
+                                if showResearchButton {
                                     ZStack {
                                         Rectangle()
                                             .foregroundColor(.clear)
@@ -283,7 +274,7 @@ struct MapView: View {
         }
         
         .onChange(of: coordinator.cameraLocation) { result in
-            self.showButton = true
+            self.showResearchButton = true
             self.checkMyLocation = true
         }
         
@@ -331,6 +322,19 @@ struct MapView: View {
         // 데이터 로드
         officeInfoServiceAPI.fetchData(postDivType: selectedButtonIndex + 1, postLatitude: coord.lat, postLongitude: coord.lng)
         coordinator.updateMapView(coord: coord, overlay: true)
+    }
+    
+    private func fetchInCurrentLocation() {
+        locationManager.stopUpdatingLocation() // 현재 위치 추적 금지
+        
+        coord = MyCoord(coordinator.cameraLocation?.lat ?? coord.lat, coordinator.cameraLocation?.lng ?? coord.lng)
+        
+        coordinator.updateMapView(coord: coord, overlay: false)
+        
+        officeInfoServiceAPI.fetchData(postDivType: selectedButtonIndex + 1, postLatitude: coord.lat, postLongitude: coord.lng)
+        
+        // 현 위치에서 검색 버튼 비활성화
+        showResearchButton = false
     }
 }
 


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #35 
- 작업 요약

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 우체국/우체통 카테고리 버튼 클릭시 검색 API 요청하도록 수정

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- 

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
https://github.com/user-attachments/assets/aa6e4701-b407-4c04-a365-3dd841963e5a

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-
