### PR TITLE
새로운 공지가 있으면 사이드 메뉴 아이콘에 뱃지 표시

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0E882AEE2B6B73DE00D8F2FC /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E882AED2B6B73DE00D8F2FC /* LocationManager.swift */; };
 		0E882AF02B6B79D800D8F2FC /* CoordinaterEtc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E882AEF2B6B79D800D8F2FC /* CoordinaterEtc.swift */; };
 		0E882AF12B6B907200D8F2FC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ACD2B5763CA003DFE83 /* AuthManager.swift */; };
+		9E0B2E732D85C3B300F6226B /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0B2E722D85C3B300F6226B /* UserDefaultsManager.swift */; };
 		9E0FA11C2B54D27A001CEEB9 /* PJ3T3_PostieApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FA11B2B54D27A001CEEB9 /* PJ3T3_PostieApp.swift */; };
 		9E0FA11E2B54D27A001CEEB9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FA11D2B54D27A001CEEB9 /* ContentView.swift */; };
 		9E0FA1202B54D27C001CEEB9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E0FA11F2B54D27C001CEEB9 /* Assets.xcassets */; };
@@ -154,6 +155,7 @@
 		23E14589945C36E243AAF134 /* Pods-PJ3T3_Postie.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PJ3T3_Postie.debug.xcconfig"; path = "Target Support Files/Pods-PJ3T3_Postie/Pods-PJ3T3_Postie.debug.xcconfig"; sourceTree = "<group>"; };
 		84267E897C35F8294DF9D1F2 /* Pods-PJ3T3_Postie.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PJ3T3_Postie.release.xcconfig"; path = "Target Support Files/Pods-PJ3T3_Postie/Pods-PJ3T3_Postie.release.xcconfig"; sourceTree = "<group>"; };
 		9E078CBF2B7207660072E5FC /* AppleUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUser.swift; sourceTree = "<group>"; };
+		9E0B2E722D85C3B300F6226B /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		9E0FA1182B54D27A001CEEB9 /* PJ3T3_Postie.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PJ3T3_Postie.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E0FA11B2B54D27A001CEEB9 /* PJ3T3_PostieApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PJ3T3_PostieApp.swift; sourceTree = "<group>"; };
 		9E0FA11D2B54D27A001CEEB9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -618,6 +620,7 @@
 				9E865CC42B839CC300CD7CAD /* NotificationManager.swift */,
 				9E4ADAD12D5F584B008BE84A /* RemoteConfigManager.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
+				9E0B2E722D85C3B300F6226B /* UserDefaultsManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -886,6 +889,7 @@
 				E36587AB2B7E34E400584965 /* GroupedLetterViewModel.swift in Sources */,
 				9E4ADAD22D5F584B008BE84A /* RemoteConfigManager.swift in Sources */,
 				9E9A8BF12B6B85640072CB75 /* PostieUser.swift in Sources */,
+				9E0B2E732D85C3B300F6226B /* UserDefaultsManager.swift in Sources */,
 				0E29F0DB2B5FDC0F005B86FB /* NaverMap.swift in Sources */,
 				0E29F0E02B602E3D005B86FB /* MyCoord.swift in Sources */,
 				E36587972B78F30F00584965 /* NoticeView.swift in Sources */,

--- a/PJ3T3_Postie/Assets.xcassets/line.horizontal.3.badge.symbolset/Contents.json
+++ b/PJ3T3_Postie/Assets.xcassets/line.horizontal.3.badge.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "custom.line.3.horizontal.badge.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/PJ3T3_Postie/Assets.xcassets/line.horizontal.3.badge.symbolset/custom.line.3.horizontal.badge.svg
+++ b/PJ3T3_Postie/Assets.xcassets/line.horizontal.3.badge.symbolset/custom.line.3.horizontal.badge.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 232.5-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="3300" height="2200">
+ <!--glyph: "", point size: 100.0, font version: "19.2d2e1", template writer version: "128"-->
+ <style>.monochrome-0 {-sfsymbols-motion-group:1}
+.monochrome-1 {-sfsymbols-motion-group:1}
+.monochrome-2 {-sfsymbols-motion-group:1}
+.monochrome-3 {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0}
+.monochrome-4 {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1}
+.multicolor-1:tintColor {-sfsymbols-motion-group:1}
+.multicolor-2:tintColor {-sfsymbols-motion-group:1}
+.multicolor-3:tintColor {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0}
+.multicolor-4:systemRedColor {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1}
+.hierarchical-1:secondary {-sfsymbols-motion-group:1}
+.hierarchical-2:secondary {-sfsymbols-motion-group:1}
+.hierarchical-3:primary {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0}
+.hierarchical-4:primary {-sfsymbols-motion-group:0}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.5332 0 39.4531-17.8711 39.4531-39.4043s-17.9688-39.4043-39.502-39.4043c-21.4844 0-39.3555 17.8711-39.3555 39.4043s17.9199 39.4043 39.4043 39.4043Zm0-7.42188c-17.7246 0-31.8848-14.209-31.8848-31.9824s14.1113-31.9824 31.8359-31.9824c17.7734 0 32.0312 14.209 32.0312 31.9824s-14.209 31.9824-31.9824 31.9824Zm-17.9688-31.9824c0 2.14844 1.51367 3.61328 3.75977 3.61328h10.498v10.5957c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094v-10.5957h10.5957c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-10.5957v-10.5469c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v10.5469h-10.498c-2.24609 0-3.75977 1.51367-3.75977 3.71094Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.2461 0 49.8047-22.6074 49.8047-49.8047 0-27.2461-22.6074-49.8047-49.8535-49.8047-27.1973 0-49.7559 22.5586-49.7559 49.8047 0 27.1973 22.6074 49.8047 49.8047 49.8047Zm0-8.30078c-23.0469 0-41.4551-18.457-41.4551-41.5039s18.3594-41.5039 41.4062-41.5039 41.5527 18.457 41.5527 41.5039-18.457 41.5039-41.5039 41.5039Zm-22.6562-41.5039c0 2.39258 1.66016 4.00391 4.15039 4.00391h14.3555v14.4043c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039v-14.4043h14.4043c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-14.4043v-14.3555c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v14.3555h-14.3555c-2.49023 0-4.15039 1.70898-4.15039 4.15039Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c34.8145 0 63.623-28.8086 63.623-63.5742 0-34.8145-28.8574-63.623-63.6719-63.623-34.7656 0-63.5254 28.8086-63.5254 63.623 0 34.7656 28.8086 63.5742 63.5742 63.5742Zm0-9.08203c-30.1758 0-54.4434-24.3164-54.4434-54.4922 0-30.2246 24.2188-54.4922 54.3945-54.4922 30.2246 0 54.541 24.2676 54.541 54.4922 0 30.1758-24.2676 54.4922-54.4922 54.4922Zm-28.8574-54.4922c0 2.58789 1.85547 4.39453 4.58984 4.39453h19.7266v19.7754c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984v-19.7754h19.7754c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-19.7754v-19.7266c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v19.7266h-19.7266c-2.73438 0-4.58984 1.85547-4.58984 4.58984Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l6.29883-17.2363h28.8086l6.29883 17.2363c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm13.4766-28.3691 11.8652-32.8613h0.244141l11.8652 32.8613Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 9.32617 8.49609 8.54492c4.29688 4.3457 9.22852 4.05273 13.8672-1.07422l53.4668-58.9355-4.83398-4.88281-53.0762 58.3984c-1.75781 2.00195-3.41797 2.49023-5.76172 0.146484l-5.85938-5.81055c-2.34375-2.29492-1.80664-4.00391 0.195312-5.81055l57.373-54.0039-4.88281-4.83398-57.959 54.4434c-4.93164 4.58984-5.32227 9.47266-1.02539 13.8184Zm32.0801-90.9668c-2.09961 2.05078-2.24609 4.93164-1.07422 6.88477 1.17188 1.80664 3.4668 2.97852 6.68945 2.14844 7.32422-1.70898 14.9414-2.00195 22.0703 2.68555l-2.92969 7.27539c-1.70898 4.15039-0.830078 7.08008 1.85547 9.81445l11.4746 11.5723c2.44141 2.44141 4.49219 2.53906 7.32422 2.05078l5.32227-0.976562 3.32031 3.36914-0.195312 2.7832c-0.195312 2.49023 0.439453 4.39453 2.88086 6.78711l3.80859 3.71094c2.39258 2.39258 5.46875 2.53906 7.8125 0.195312l14.5508-14.5996c2.34375-2.34375 2.24609-5.32227-0.146484-7.71484l-3.85742-3.80859c-2.39258-2.39258-4.24805-3.17383-6.64062-2.97852l-2.88086 0.244141-3.22266-3.17383 1.2207-5.61523c0.634766-2.83203-0.146484-5.0293-3.07617-7.95898l-10.9863-10.9375c-16.6992-16.6016-38.8672-16.2109-53.3203-1.75781Zm7.4707 1.85547c12.1582-8.88672 28.6133-7.37305 39.7461 3.75977l12.1582 12.0605c1.17188 1.17188 1.36719 2.09961 1.02539 3.80859l-1.61133 7.42188 7.51953 7.42188 4.93164-0.292969c1.26953-0.0488281 1.66016 0.0488281 2.63672 1.02539l2.88086 2.88086-12.207 12.207-2.88086-2.88086c-0.976562-0.976562-1.12305-1.36719-1.07422-2.68555l0.341797-4.88281-7.4707-7.42188-7.61719 1.26953c-1.61133 0.341797-2.34375 0.195312-3.56445-0.976562l-10.0098-10.0098c-1.26953-1.17188-1.41602-2.00195-0.634766-3.85742l4.39453-10.4492c-7.8125-7.27539-17.9688-10.4004-28.125-7.42188-0.78125 0.195312-1.07422-0.439453-0.439453-0.976562Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.5.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 15 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from </text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="512.456" x2="512.456" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="606.966" x2="606.966" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1401.11" x2="1401.11" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="1498.57" x2="1498.57" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2881.94" x2="2881.94" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="2984.86" x2="2984.86" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2881.94 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M15.8691-8.78906L87.0605-8.78906C90.4785-8.78906 93.1641-11.8164 93.1641-15.1367C93.1641-18.6035 90.5273-21.4844 87.0605-21.4844L15.8691-21.4844C12.4512-21.4844 9.76562-18.5059 9.76562-15.1367C9.76562-11.9141 12.5-8.78906 15.8691-8.78906Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:secondary SFSymbolsPreviewWireframe" d="M15.8691-28.9062L87.0605-28.9062C90.4785-28.9062 93.1641-31.9336 93.1641-35.2539C93.1641-38.7207 90.5273-41.6016 87.0605-41.6016L15.8691-41.6016C12.4512-41.6016 9.76562-38.623 9.76562-35.2539C9.76562-32.0312 12.5-28.9062 15.8691-28.9062Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:secondary SFSymbolsPreviewWireframe" d="M15.8691-48.9746L87.0605-48.9746C90.4785-48.9746 93.1641-52.002 93.1641-55.3223C93.1641-58.7891 90.5273-61.6699 87.0605-61.6699L15.8691-61.6699C12.4512-61.6699 9.76562-58.6914 9.76562-55.3223C9.76562-52.0996 12.5-48.9746 15.8691-48.9746Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M92.6279 12.2382C103.174 12.2382 111.866 3.54685 111.866-6.99995C111.866-17.5469 103.174-26.2382 92.6279-26.2382C82.0811-26.2382 73.3896-17.5469 73.3896-6.99995C73.3896 3.54685 82.0811 12.2382 92.6279 12.2382Z"/>
+   <path class="monochrome-4 multicolor-4:systemRedColor hierarchical-4:primary SFSymbolsPreviewWireframe" d="M92.6279 5.89065C99.6591 5.89065 105.518 0.03125 105.518-6.99995C105.518-14.0313 99.6591-19.8907 92.6279-19.8907C85.5966-19.8907 79.7373-14.0313 79.7373-6.99995C79.7373 0.03125 85.5966 5.89065 92.6279 5.89065Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1401.11 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M13.0371-15.625L84.375-15.625C86.2305-15.625 87.6953-17.0898 87.6953-18.9453C87.6953-20.8008 86.2305-22.2656 84.375-22.2656L13.0371-22.2656C11.2305-22.2656 9.76562-20.8008 9.76562-18.9453C9.76562-17.0898 11.2305-15.625 13.0371-15.625Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:secondary SFSymbolsPreviewWireframe" d="M13.0371-31.8848L84.375-31.8848C86.2305-31.8848 87.6953-33.3496 87.6953-35.2051C87.6953-37.0605 86.2305-38.5254 84.375-38.5254L13.0371-38.5254C11.2305-38.5254 9.76562-37.0605 9.76562-35.2051C9.76562-33.3496 11.2305-31.8848 13.0371-31.8848Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:secondary SFSymbolsPreviewWireframe" d="M13.0371-48.1934L84.375-48.1934C86.2305-48.1934 87.6953-49.6582 87.6953-51.4648C87.6953-53.3203 86.2305-54.7852 84.375-54.7852L13.0371-54.7852C11.2305-54.7852 9.76562-53.3203 9.76562-51.4648C9.76562-49.6582 11.2305-48.1934 13.0371-48.1934Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M87.7142 12.3603C98.3099 12.3603 107.05 3.62005 107.05-6.97565C107.05-17.6202 98.3099-26.3603 87.7142-26.3603C77.0697-26.3603 68.3783-17.6202 68.3783-6.97565C68.3783 3.62005 77.0697 12.3603 87.7142 12.3603Z"/>
+   <path class="monochrome-4 multicolor-4:systemRedColor hierarchical-4:primary SFSymbolsPreviewWireframe" d="M87.7142 6.64745C95.1849 6.64745 101.337 0.49505 101.337-6.97565C101.337-14.4952 95.1849-20.6474 87.7142-20.6474C80.1947-20.6474 74.0424-14.4952 74.0424-6.97565C74.0424 0.49505 80.1947 6.64745 87.7142 6.64745Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 512.456 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M10.8574-15.5342L83.6484-15.5342C84.2324-15.5342 84.7437-16 84.7437-16.6294C84.7437-17.2134 84.2324-17.7246 83.6484-17.7246L10.8574-17.7246C10.2769-17.7246 9.76562-17.2134 9.76562-16.6294C9.76562-16 10.2769-15.5342 10.8574-15.5342Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:secondary SFSymbolsPreviewWireframe" d="M10.8574-33.9736L83.6484-33.9736C84.2324-33.9736 84.7437-34.4849 84.7437-35.0688C84.7437-35.6528 84.2324-36.1641 83.6484-36.1641L10.8574-36.1641C10.2769-36.1641 9.76562-35.6528 9.76562-35.0688C9.76562-34.4849 10.2769-33.9736 10.8574-33.9736Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:secondary SFSymbolsPreviewWireframe" d="M10.8574-52.4165L83.6484-52.4165C84.2324-52.4165 84.7437-52.9277 84.7437-53.5083C84.7437-54.0923 84.2324-54.6035 83.6484-54.6035L10.8574-54.6035C10.2769-54.6035 9.76562-54.0923 9.76562-53.5083C9.76562-52.9277 10.2769-52.4165 10.8574-52.4165Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M85.059 7.5923C93.0663 7.5923 99.6723 0.9863 99.6723-6.9756C99.6723-14.9863 93.0663-21.5923 85.059-21.5923C77.0482-21.5923 70.4457-14.9863 70.4457-6.9756C70.4457 0.9863 77.0482 7.5923 85.059 7.5923Z"/>
+   <path class="monochrome-4 multicolor-4:systemRedColor hierarchical-4:primary SFSymbolsPreviewWireframe" d="M85.059 4.5586C91.349 4.5586 96.5932-0.6855 96.5932-6.9756C96.5932-13.3145 91.349-18.5132 85.059-18.5132C78.7201-18.5132 73.5214-13.3145 73.5214-6.9756C73.5214-0.6855 78.7201 4.5586 85.059 4.5586Z"/>
+  </g>
+ </g>
+</svg>

--- a/PJ3T3_Postie/Core/Home/View/HomeView.swift
+++ b/PJ3T3_Postie/Core/Home/View/HomeView.swift
@@ -224,10 +224,6 @@ struct DividerView: View {
     }
 }
 
-private func getValueFromUserDefaults<T>(key: String, defaultValue: T) -> T {
-    return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
-}
-
 //#Preview {
 //    HomeView()
 //}

--- a/PJ3T3_Postie/Core/Home/View/HomeView.swift
+++ b/PJ3T3_Postie/Core/Home/View/HomeView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct HomeView: View {
+    
+    @EnvironmentObject var remoteConfigManager: RemoteConfigManager
     @ObservedObject var firestoreManager = FirestoreManager.shared
     @ObservedObject private var counter = Counter(interval: 1)
     @AppStorage("isTabGroupButton") private var isTabGroupButton: Bool = true
@@ -21,6 +23,7 @@ struct HomeView: View {
     @State private var currentColorPage: Int = 0
     @State private var scrollTarget: Int? = nil
     @State private var isBouncing = true
+    @State private var hasNewNotice: Bool = false
     
     var tabSelection: TabSelection
     
@@ -83,9 +86,17 @@ struct HomeView: View {
                                     self.isSideMenuOpen.toggle()
                                 }
                             }) {
-                                Image(systemName: "line.horizontal.3")
-                                    .imageScale(.large)
-                                    .foregroundStyle(postieColors.tabBarTintColor)
+                                if hasNewNotice {
+                                    Image("line.horizontal.3.badge")
+                                        .imageScale(.large)
+                                        .symbolRenderingMode(.multicolor)
+                                        .foregroundStyle(postieColors.tabBarTintColor, .red)
+                                        .padding(.top, 5)
+                                } else {
+                                    Image(systemName: "line.horizontal.3")
+                                        .imageScale(.large)
+                                        .foregroundStyle(postieColors.tabBarTintColor)
+                                }
                             }
                         }
                         .background(postieColors.backGroundColor)
@@ -168,6 +179,8 @@ struct HomeView: View {
                             NotificationManager.shared.requestPermission()
                         }
                     }
+                    
+                    hasNewNotice = remoteConfigManager.getString(from: .latest_notice_uuid) != UserDefaultsManager.get(forKey: .lastestNoticeUUID) ?? ""
                 }
             }
         }

--- a/PJ3T3_Postie/Core/Home/View/HomeView.swift
+++ b/PJ3T3_Postie/Core/Home/View/HomeView.swift
@@ -164,7 +164,15 @@ struct HomeView: View {
                             .edgesIgnoringSafeArea(.all)
                     }
                     
-                    SettingView(isSideMenuOpen: $isSideMenuOpen, currentGroupPage: $currentGroupPage, isTabGroupButton: $isTabGroupButton, currentColorPage: $currentColorPage, profileImage: $profileImage, profileImageTemp: $profileImageTemp)
+                    SettingView(
+                        isSideMenuOpen: $isSideMenuOpen,
+                        currentGroupPage: $currentGroupPage,
+                        isTabGroupButton: $isTabGroupButton,
+                        currentColorPage: $currentColorPage,
+                        profileImage: $profileImage,
+                        profileImageTemp: $profileImageTemp,
+                        hasNewNotice: $hasNewNotice
+                    )
                         .offset(x: isSideMenuOpen ? 0 : UIScreen.main.bounds.width)
                         .animation(.easeInOut, value: 1)
                 }

--- a/PJ3T3_Postie/Core/Home/View/HomeView.swift
+++ b/PJ3T3_Postie/Core/Home/View/HomeView.swift
@@ -188,7 +188,7 @@ struct HomeView: View {
                         }
                     }
                     
-                    hasNewNotice = remoteConfigManager.getString(from: .latest_notice_uuid) != UserDefaultsManager.get(forKey: .lastestNoticeUUID) ?? ""
+                    hasNewNotice = remoteConfigManager.getString(from: .latest_notice_uuid) != UserDefaultsManager.get(forKey: .latestNoticeUUID) ?? ""
                 }
             }
         }

--- a/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
@@ -72,7 +72,7 @@ struct NoticeView: View {
                                             .onAppear {
                                                 if notice.id == latestNoticeUUID {
                                                     hasNewNotice = false
-                                                    UserDefaultsManager.set(latestNoticeUUID, forKey: .lastestNoticeUUID)
+                                                    UserDefaultsManager.set(latestNoticeUUID, forKey: .latestNoticeUUID)
                                                 }
                                             }
                                     }

--- a/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
@@ -8,8 +8,13 @@
 import SwiftUI
 
 struct NoticeView: View {
+    
+    @EnvironmentObject var remoteConfigManager: RemoteConfigManager
     @ObservedObject var firestoreNoticeManager = FirestoreNoticeManager.shared
     @StateObject private var viewModel = NoticeViewModel()
+    
+    @State var latestNoticeUUID: String = ""
+    @Binding var hasNewNotice: Bool
     
     var body: some View {
         ZStack {
@@ -80,9 +85,23 @@ struct NoticeView: View {
                             .padding(.top, 10)
                         } label: {
                             VStack(alignment: .leading) {
-                                Text(notice.date.toString())
-                                    .font(.caption)
-                                    .foregroundColor(postieColors.dividerColor)
+                                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                                    Text(notice.date.toString())
+                                        .font(.caption)
+                                        .foregroundColor(postieColors.dividerColor)
+                                        .padding(.trailing, 4)
+                                    
+                                    if hasNewNotice, notice.id == latestNoticeUUID {
+                                        Text("New")
+                                            .font(.caption)
+                                            .foregroundStyle(.white)
+                                            .padding(.horizontal, 4)
+                                            .background {
+                                                RoundedRectangle(cornerRadius: 8)
+                                                    .foregroundStyle(.red)
+                                            }
+                                    }
+                                }
                                 
                                 Text(notice.title)
                                     .multilineTextAlignment(.leading)
@@ -96,6 +115,7 @@ struct NoticeView: View {
                     if firestoreNoticeManager.notices.isEmpty {
                         firestoreNoticeManager.fetchAllNotices()
                     }
+                    latestNoticeUUID = remoteConfigManager.getString(from: .latest_notice_uuid) ?? ""
                 }
             }
             .padding(.leading)

--- a/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/NoticeView.swift
@@ -69,6 +69,12 @@ struct NoticeView: View {
                                         Text(part.0)
                                             .font(.callout)
                                             .fontWeight(part.1 ? .bold : .regular)
+                                            .onAppear {
+                                                if notice.id == latestNoticeUUID {
+                                                    hasNewNotice = false
+                                                    UserDefaultsManager.set(latestNoticeUUID, forKey: .lastestNoticeUUID)
+                                                }
+                                            }
                                     }
                                     
                                     HStack {

--- a/PJ3T3_Postie/Core/Setting/View/ProfileEditView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/ProfileEditView.swift
@@ -96,7 +96,7 @@ struct ProfileEditView: View {
                             }
                         }
                         .customOnChange(profileImageTemp) { newValue in
-                            saveToUserDefaults(value: newValue, key: "profileImageTemp")
+                            UserDefaultsManager.set(newValue, forKey: .profileImageTemp)
                         }
                     }
                 }

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -29,9 +29,15 @@ struct SettingView: View {
             Text(title)
             
             if hasAlert {
-                Circle()
-                    .fill(.red)
-                    .frame(width: 8, height: 8)
+                Text("N")
+                    .foregroundStyle(.white)
+                    .font(.system(size: 9))
+                    .fontWeight(.bold)
+                    .padding(4)
+                    .background(
+                        Circle()
+                            .fill(.red)
+                    )
             }
             
             Spacer()

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SettingView: View {
+    
+    @EnvironmentObject var remoteConfigManager: RemoteConfigManager
     @ObservedObject var authManager = AuthManager.shared
     
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
@@ -17,13 +19,20 @@ struct SettingView: View {
     @Binding var currentColorPage: Int
     @Binding var profileImage: String
     @Binding var profileImageTemp: String
+    @Binding var hasNewNotice: Bool
     
-    private func settingItemView(imageName: String, title: String) -> some View {
-        HStack {
+    private func settingItemView(imageName: String, title: String, hasAlert: Bool = false) -> some View {
+        HStack(alignment: .center) {
             Image(systemName: imageName)
                 .font(imageName == "megaphone" ? .callout : .body)
             
             Text(title)
+            
+            if hasAlert {
+                Circle()
+                    .fill(.red)
+                    .frame(width: 8, height: 8)
+            }
             
             Spacer()
             
@@ -116,8 +125,8 @@ struct SettingView: View {
                     settingItemView(imageName: "bell", title: "알림 설정")
                 }
                 
-                NavigationLink(destination: NoticeView()) {
-                    settingItemView(imageName: "megaphone", title: "공지사항")
+                NavigationLink(destination: NoticeView(hasNewNotice: $hasNewNotice)) {
+                    settingItemView(imageName: "megaphone", title: "공지사항", hasAlert: hasNewNotice)
                 }
                 
                 NavigationLink(destination: QuestionView()) {

--- a/PJ3T3_Postie/Core/Setting/View/ThemeView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/ThemeView.swift
@@ -165,7 +165,7 @@ struct ThemeView: View {
                             .tabViewStyle(PageTabViewStyle())
                             .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
                             .customOnChange(isThemeGroupButton) { newValue in
-                                saveToUserDefaults(value: newValue, key: "IsThemeGroupButton")
+                                UserDefaultsManager.set(newValue, forKey: .IsThemeGroupButton)
                             }
                         } else if selectedLayoutMode == 1 {
                             ScrollView {
@@ -276,7 +276,7 @@ struct ThemeView: View {
                             .tabViewStyle(PageTabViewStyle())
                             .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
                             .customOnChange(isTabGroupButton) { newValue in
-                                saveToUserDefaults(value: newValue, key: "IsTabGroupButton")
+                                UserDefaultsManager.set(newValue, forKey: .IsTabGroupButton)
                             }
                         } else {
                             ScrollView {
@@ -352,10 +352,6 @@ struct CustomImageModifier: ViewModifier {
             .frame(height: height < 650 ? height * 0.7 : height * 0.75)
             .shadow(color: Color.postieBlack.opacity(0.1), radius: 3)
     }
-}
-
-func saveToUserDefaults<T>(value: T, key: String) {
-    UserDefaults.standard.set(value, forKey: key)
 }
 
 //#Preview {

--- a/PJ3T3_Postie/Core/Setting/ViewModel/AlertViewModel.swift
+++ b/PJ3T3_Postie/Core/Setting/ViewModel/AlertViewModel.swift
@@ -13,12 +13,11 @@ class AlertViewModel: ObservableObject {
     @Published var allAlert: Bool
     @Published var slowAlert: Bool
     
-    private let userDefaults = UserDefaults.standard
     
     init() {
-        self.isThemeGroupButton = userDefaults.integer(forKey: "isThemeGroupButton")
-        self.allAlert = userDefaults.bool(forKey: "allAlert")
-        self.slowAlert = userDefaults.bool(forKey: "slowAlert")
+        self.isThemeGroupButton = UserDefaultsManager.get(forKey: .IsThemeGroupButton) ?? 0
+        self.allAlert = UserDefaultsManager.get(forKey: .allAlert) ?? false
+        self.slowAlert = UserDefaultsManager.get(forKey: .slowAlert) ?? false
     }
     
     func checkNotificationPermission() async -> Bool {

--- a/PJ3T3_Postie/Core/Setting/ViewModel/NoticeViewModel.swift
+++ b/PJ3T3_Postie/Core/Setting/ViewModel/NoticeViewModel.swift
@@ -11,10 +11,9 @@ class NoticeViewModel: ObservableObject {
     @Published var isExpanded: Bool = false
     @Published var isThemeGroupButton: Int
     
-    private let userDefaults = UserDefaults.standard
     
     init() {
-        self.isThemeGroupButton = userDefaults.integer(forKey: "isThemeGroupButton")
+        self.isThemeGroupButton = UserDefaultsManager.get(forKey: .IsThemeGroupButton) ?? 0
     }
     
     func parseText(_ text: String) -> [(String, Bool)] {

--- a/PJ3T3_Postie/Extenstions/Color.swift
+++ b/PJ3T3_Postie/Extenstions/Color.swift
@@ -32,16 +32,15 @@ struct ThemeData {
 
 class ThemeManager {
     static let shared = ThemeManager()
-    private let userDefaultsKey = "CurrentThemeIndex"
     
     private(set) var currentIndex: Int {
         didSet {
-            UserDefaults.standard.set(currentIndex, forKey: userDefaultsKey)
+            UserDefaultsManager.set(currentIndex, forKey: .CurrentThemeIndex)
         }
     }
     
     private init() {
-        currentIndex = UserDefaults.standard.integer(forKey: userDefaultsKey)
+        currentIndex = UserDefaultsManager.get(forKey: .CurrentThemeIndex) ?? 0
     }
     
     static let themeColors = [

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -33,12 +33,12 @@ class AuthManager: ObservableObject {
     }
     
     func checkAppLaunch() {
-        let userDefaults = UserDefaults.standard
+        let isFirstOpen: Bool? = UserDefaultsManager.get(forKey: .appFirstTimeOpend)
 
-        Logger.auth.info("UserDefault \(userDefaults.value(forKey: "appFirstTimeOpend").debugDescription)")
+        Logger.auth.info("UserDefault \(isFirstOpen.debugDescription)")
         //앱이 설치된 후 처음 실행 되는 것이라면 nil이다.
-        if userDefaults.value(forKey: "appFirstTimeOpend") == nil {
-            userDefaults.setValue(true, forKey: "appFirstTimeOpend")
+        if isFirstOpen == nil {
+            UserDefaultsManager.set(true, forKey: .appFirstTimeOpend)
             do {
                 try Auth.auth().signOut()
             } catch {

--- a/PJ3T3_Postie/Manager/RemoteConfigManager.swift
+++ b/PJ3T3_Postie/Manager/RemoteConfigManager.swift
@@ -11,6 +11,7 @@ import OSLog
 
 enum RemoteConfigKeys: String {
     case is_force_update
+    case latest_notice_uuid
 }
 
 final class RemoteConfigManager: ObservableObject {
@@ -22,7 +23,7 @@ final class RemoteConfigManager: ObservableObject {
     }
     
     private func fetchConfig() {
-        settings.minimumFetchInterval = 3600
+        settings.minimumFetchInterval = 1
         remoteConfig.configSettings = settings
         
         remoteConfig.fetch() { [weak self] status, error in

--- a/PJ3T3_Postie/Manager/RemoteConfigManager.swift
+++ b/PJ3T3_Postie/Manager/RemoteConfigManager.swift
@@ -23,7 +23,7 @@ final class RemoteConfigManager: ObservableObject {
     }
     
     private func fetchConfig() {
-        settings.minimumFetchInterval = 1
+        settings.minimumFetchInterval = 3600
         remoteConfig.configSettings = settings
         
         remoteConfig.fetch() { [weak self] status, error in

--- a/PJ3T3_Postie/Manager/UserDefaultsManager.swift
+++ b/PJ3T3_Postie/Manager/UserDefaultsManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum UserDefaultsKey: String {
     case appFirstTimeOpend // Bool: 앱을 설치 후 처음 실행했는지 여부
-    case lastestNoticeUUID
+    case latestNoticeUUID
     
     case profileImageTemp
     case IsThemeGroupButton

--- a/PJ3T3_Postie/Manager/UserDefaultsManager.swift
+++ b/PJ3T3_Postie/Manager/UserDefaultsManager.swift
@@ -1,0 +1,39 @@
+//
+//  UserDefaultsManager.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 3/15/25.
+//
+
+import Foundation
+
+enum UserDefaultsKey: String {
+    case appFirstTimeOpend // Bool: 앱을 설치 후 처음 실행했는지 여부
+    
+    case profileImageTemp
+    case IsThemeGroupButton
+    case IsTabGroupButton
+    case allAlert
+    case slowAlert
+    case CurrentThemeIndex
+}
+
+struct UserDefaultsManager {
+    
+    private static let userDefaults = UserDefaults.standard
+
+    // 저장 (Set)
+    static func set<T>(_ value: T, forKey key: UserDefaultsKey) {
+        userDefaults.set(value, forKey: key.rawValue)
+    }
+
+    // 불러오기 (Get)
+    static func get<T>(forKey key: UserDefaultsKey) -> T? {
+        return userDefaults.object(forKey: key.rawValue) as? T
+    }
+
+    // 삭제 (Delete)
+    static func delete(forKey key: UserDefaultsKey) {
+        userDefaults.removeObject(forKey: key.rawValue)
+    }
+}

--- a/PJ3T3_Postie/Manager/UserDefaultsManager.swift
+++ b/PJ3T3_Postie/Manager/UserDefaultsManager.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum UserDefaultsKey: String {
     case appFirstTimeOpend // Bool: 앱을 설치 후 처음 실행했는지 여부
+    case lastestNoticeUUID
     
     case profileImageTemp
     case IsThemeGroupButton


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #43 
- 작업 요약: RemoteConfig의 값을 토대로 새 공지가 있는지를 판별하여, 읽지 않은 새 공지가 있다면 뱃지 표시

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- UserDefault를 Manager로 관리하도록 리팩토링
- 홈 뷰의 SideMenuView 아이콘(심볼) 추가
- RemoteConfig enum 추가
- 로직
  1. 홈 진입시 UserDefaults의 값과 Remote Config의 공지 id 값 비교해 일치하지 않는다면 뱃지 표시
  2. 홈에 뱃지 표시중이라면 사이드 메뉴 열었을 때 공지사항 옆에 뱃지 표시
  3. 공지사항 뷰 진입시 Remote Config의 공지 id 값과 일치하는 공지의 날짜 옆에 New 뱃지 표시
  4. Remote Config의 공지 id 값과 일치하는 공지를 펼치면 UserDefaults의 값을 Remote Config의 공지 id 값으로 업데이트하고 뱃지 표시하지 않도록 Bool 값 변경

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [SF Symbols. 개발자와 디자이너를 위한 Custom Symbol 만드는 법](https://medium.com/official-podo/%EA%B0%9C%EB%B0%9C%EC%9E%90%EC%99%80-%EB%94%94%EC%9E%90%EC%9D%B4%EB%84%88%EB%A5%BC-%EC%9C%84%ED%95%9C-custom-sf-symbol-%EB%A7%8C%EB%93%9C%EB%8A%94-%EB%B2%95-374b14448db6)
- [[iOS] SF Symbols — Color - Monochrome, Hierarchical, Palette, Multicolor 네가지 SymbolRenderingMode 를 알아봅시다](https://sujinnaljin.medium.com/ios-sf-symbols-colors-2bb3e9c3632d)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|홈|사이드 메뉴|공지상세|
|:-:|:-:|:-:| 
|<img width="216" src="https://github.com/user-attachments/assets/b706a547-d091-449c-8d58-fecfbcd4d4e5">|<img width="216" src="https://github.com/user-attachments/assets/226e13c9-f599-4798-959a-7a7420bc4874">|<img width="216" src="https://github.com/user-attachments/assets/cc4f2df6-1a0a-4ca3-84fa-7172595f4cd5">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 뱃지 위치에 대한 다른 의견 있다면 말씀 주세요!
