### PR TITLE
영업시간 또는 점심시간이 빈 문자열이면 지도에 글자가 표시되지 않도록 수정

### DIFF
--- a/PJ3T3_Postie/Core/Map/View/Coordinator.swift
+++ b/PJ3T3_Postie/Core/Map/View/Coordinator.swift
@@ -163,14 +163,26 @@ class Coordinator: NSObject, ObservableObject, NMFMapViewCameraDelegate {
     
     // 마커 찍는 행위
     func addMarkerAndInfoWindow(latitude: Double, longitude: Double, caption: String, time: String, lunchtime: String) {
-        
         let marker = NMFMarker()
+        var subCation: String = ""
+        
+        if !time.isEmpty {
+            subCation = "영업시간 \(time)"
+        }
+        
+        if !lunchtime.isEmpty {
+            if !subCation.isEmpty {
+                subCation += "\n점심시간 \(lunchtime)"
+            } else {
+                subCation = "점심시간 \(lunchtime)"
+            }
+        }
         
         marker.captionText = caption
         //        marker.iconTintColor = UIColor.red
         //        marker.captionColor = UIColor.orange
         marker.captionTextSize = 16
-        marker.subCaptionText = "영업시간 \(time) \n 점심시간 \(lunchtime)"
+        marker.subCaptionText = subCation
         
         marker.position = NMGLatLng(lat: latitude, lng: longitude)
         marker.mapView = view.mapView

--- a/PJ3T3_Postie/Core/Map/View/MapView.swift
+++ b/PJ3T3_Postie/Core/Map/View/MapView.swift
@@ -263,12 +263,7 @@ struct MapView: View {
         .onChange(of: officeInfoServiceAPI.infos) { newInfos in
 
             for result in newInfos {
-                var lunchtime: String = ""
-                if result.lunchTime == "null" {
-                    lunchtime = "없음"
-                } else {
-                    lunchtime = result.lunchTime!
-                }
+                var lunchtime = result.lunchTime ?? "없음"
                 coordinator.addMarkerAndInfoWindow(latitude: Double(result.postLat)!, longitude: Double(result.postLon)!, caption: result.postNm, time: result.postTime, lunchtime: lunchtime)
             }
         }


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #51 
- 작업 요약: 영업시간 또는 점심시간이 빈 문자열이면 지도에 글자가 표시되지 않도록 수정

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 우체국, 우체통 둘 다 영업시간 또는 점심시간이 빈 문자열이면 지도에 영업시간 또는 점심시간이라는 글자 미노출 처리

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- 

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|우체국|<img width="216" src="https://github.com/user-attachments/assets/0b625307-d5af-4fa4-87b6-c7e49e6ae91b">|<img width="216" src="https://github.com/user-attachments/assets/1742a0c5-9947-41fc-8321-e3808b6ba4a0">|
|우체통|<img width="216" src="https://github.com/user-attachments/assets/ea0c7521-e8cb-4040-99bf-6abd71787249">|<img width="216" src="https://github.com/user-attachments/assets/6fcc0361-194f-4393-9faa-20624afba21b">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 기존에 dev branch에 머지된 내용을 강제 push로 날려버려야 할 것 같습니다. 
- 리팩토링은 이번 릴리즈 안에 해결되기 어려울 것 같아 우선 탑재 가능한 작업 먼저 PR 작성합니다.